### PR TITLE
volume-1] 회원가입, 정보 조회, 포인트 조회 및 충전 기능 구현

### DIFF
--- a/apps/commerce-api/src/main/java/com/loopers/application/point/PointFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/point/PointFacade.java
@@ -1,0 +1,31 @@
+package com.loopers.application.point;
+
+import com.loopers.domain.point.PointEntity;
+import com.loopers.domain.point.PointService;
+import com.loopers.infrastructure.user.UserJpaRepository;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Component
+public class PointFacade {
+    private final PointService pointService;
+    private final UserJpaRepository userJpaRepository;
+
+    public Optional<PointInfo> getPointInfo(String userId){
+        return pointService.getPoint(userId)
+                .map(PointInfo::from);
+    }
+
+    public PointInfo chargePoint(String userId, int amount) {
+        if(!userJpaRepository.existsByUserId(userId)){
+            throw new CoreException(ErrorType.NOT_FOUND);
+        }
+        PointEntity pointEntity = pointService.chargePoint(userId, amount);
+        return PointInfo.from(pointEntity);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/point/PointInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/point/PointInfo.java
@@ -1,0 +1,11 @@
+package com.loopers.application.point;
+
+import com.loopers.domain.point.PointEntity;
+
+public record PointInfo(int balance) {
+    public static PointInfo from(PointEntity entity) {
+        return new PointInfo(
+                entity.getBalance()
+        );
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/user/UserFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/user/UserFacade.java
@@ -1,0 +1,18 @@
+package com.loopers.application.user;
+
+
+import com.loopers.domain.user.UserEntity;
+import com.loopers.domain.user.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class UserFacade {
+    private final UserService userService;
+
+    public UserInfo getUserInfo(String userId){
+        UserEntity userEntity = userService.getUserEntity(userId);
+                return UserInfo.from(userEntity);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/user/UserInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/user/UserInfo.java
@@ -1,0 +1,14 @@
+package com.loopers.application.user;
+
+import com.loopers.domain.user.UserEntity;
+
+public record UserInfo(String userId, String name, String email){
+    public static UserInfo from(UserEntity userEntity){
+        return new UserInfo(
+                userEntity.getUserId(),
+                userEntity.getName(),
+                userEntity.getUserId()
+        );
+    }
+}
+

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/PointEntity.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/PointEntity.java
@@ -1,0 +1,48 @@
+package com.loopers.domain.point;
+
+import com.loopers.domain.user.UserEntity;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "point_entity")
+@Getter
+@NoArgsConstructor
+public class PointEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private int balance;
+
+    private String userId;
+
+    public PointEntity(int balance, String userId) {
+        if(balance < 0){
+            throw new CoreException(ErrorType.BAD_REQUEST);
+        }
+        this.balance = balance;
+        this.userId = userId;
+    }
+
+    public void increase(int amount){
+        if(amount <= 0){
+            throw new CoreException(ErrorType.BAD_REQUEST);
+        }
+        int newBalance = this.balance + amount;
+        this.balance = newBalance;
+    }
+
+    public void decrease(int amount){
+        if(amount <= 0){
+            throw new CoreException(ErrorType.BAD_REQUEST);
+        }
+        int newBalance = this.balance - amount;
+        this.balance = newBalance;
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/PointEntity.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/PointEntity.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "point_entity")
+@Table(name = "point")
 @Getter
 @NoArgsConstructor
 public class PointEntity {

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/PointRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/PointRepository.java
@@ -1,0 +1,7 @@
+package com.loopers.domain.point;
+
+import java.util.Optional;
+
+public interface PointRepository {
+    Optional<PointEntity> findByUserId(String userId);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/PointService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/PointService.java
@@ -1,0 +1,29 @@
+package com.loopers.domain.point;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import org.springframework.transaction.annotation.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Component
+public class PointService {
+
+    private final PointRepository pointRepository;
+
+    @Transactional(readOnly = true)
+    public Optional<PointEntity> getPoint(String userId){
+        return pointRepository.findByUserId(userId);
+    }
+
+    public PointEntity chargePoint(String userId, int amount) {
+        PointEntity pointEntity = pointRepository.findByUserId(userId)
+                .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "[id = " + userId + "] 의 포인트를 찾을 수 없습니다."));
+
+        pointEntity.increase(amount);
+        return pointEntity;
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserEntity.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserEntity.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 
 
 @Entity
-@Table(name = "user_entity")
+@Table(name = "user")
 @Getter
 @NoArgsConstructor
 public class UserEntity{

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserEntity.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserEntity.java
@@ -1,14 +1,12 @@
 package com.loopers.domain.user;
 
-import com.loopers.domain.BaseEntity;
-import com.loopers.domain.point.PointEntity;
+
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.awt.*;
 
 
 @Entity

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserEntity.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserEntity.java
@@ -1,0 +1,67 @@
+package com.loopers.domain.user;
+
+import com.loopers.domain.BaseEntity;
+import com.loopers.domain.point.PointEntity;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.awt.*;
+
+
+@Entity
+@Table(name = "user_entity")
+@Getter
+@NoArgsConstructor
+public class UserEntity{
+    @Id
+    private String userId;
+    private String name;
+    private String gender;
+    private String email;
+    private String birth;
+
+
+    private final String PATTERN_USER_ID = "^[a-zA-Z0-9]{1,10}$";
+    private final String PATTERN_EMAIL = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,6}$";
+    private final String PATTERN_BIRTH = "^\\d{4}-\\d{2}-\\d{2}$";
+
+    public UserEntity(
+            String userId,
+            String name,
+            String gender,
+            String birth,
+            String email
+
+    ){
+        if(userId == null || !userId.matches(PATTERN_USER_ID)){
+            throw new CoreException(
+                    ErrorType.BAD_REQUEST,
+                    "ID는 영문 및 숫자 10자 이내로 입력해야 합니다."
+            );
+        }
+
+        if(email == null || !email.matches(PATTERN_EMAIL)){
+            throw new CoreException(
+                    ErrorType.BAD_REQUEST,
+                    "이메일은 xx@yy.zz 형식이어야 합니다."
+            );
+        }
+
+        if(birth == null || !birth.matches(PATTERN_BIRTH)){
+            throw new CoreException(
+                    ErrorType.BAD_REQUEST,
+                    "생년월일은 'yyyy-MM-dd' 형식이어야 합니다."
+            );
+        }
+
+        this.userId = userId;
+        this.name = name;
+        this.gender = gender;
+        this.birth = birth;
+        this.email = email;
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
@@ -1,0 +1,52 @@
+package com.loopers.domain.user;
+
+import com.loopers.infrastructure.user.UserJpaRepository;
+import com.loopers.interfaces.api.user.UserV1Dto;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class UserService {
+
+    private final UserJpaRepository userJpaRepository;
+
+    @Transactional(readOnly = true)
+    public UserEntity getUserEntity(String userId) {
+        return userJpaRepository.findById(userId)
+                .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "[id = " + userId + "] 회원을 찾을 수 없습니다."));
+    }
+
+    @Transactional
+    public UserV1Dto.UserResponse signUp(UserV1Dto.SignUpRequest request) {
+        // 1. 중복 userId 체크
+        boolean exists = userJpaRepository.existsByUserId(request.userId());
+        if (exists) {
+            throw new CoreException(ErrorType.CONFLICT, "이미 존재하는 사용자 ID입니다.");
+        }
+
+        // 2. UserEntity 생성
+        UserEntity userEntity = new UserEntity(
+                request.userId(),
+                request.name(),
+                request.gender(),
+                request.birth(),
+                request.email()
+        );
+
+        // 3. 저장
+        UserEntity savedUser = userJpaRepository.save(userEntity);
+
+        // 4. DTO 반환
+        return new UserV1Dto.UserResponse(
+                savedUser.getUserId(),
+                savedUser.getName(),
+                savedUser.getGender(),
+                savedUser.getBirth(),
+                savedUser.getEmail()
+        );
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/point/PointJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/point/PointJpaRepository.java
@@ -1,0 +1,10 @@
+package com.loopers.infrastructure.point;
+
+import com.loopers.domain.point.PointEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PointJpaRepository extends JpaRepository<PointEntity, String> {
+    Optional<PointEntity> findByUserId(String userId);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/point/PointRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/point/PointRepositoryImpl.java
@@ -1,0 +1,19 @@
+package com.loopers.infrastructure.point;
+
+import com.loopers.domain.point.PointEntity;
+import com.loopers.domain.point.PointRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Component
+public class PointRepositoryImpl implements PointRepository {
+    private final PointJpaRepository pointJpaRepository;
+
+    @Override
+    public Optional<PointEntity> findByUserId(String userId){
+        return pointJpaRepository.findByUserId(userId);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserJpaRepository.java
@@ -1,0 +1,8 @@
+package com.loopers.infrastructure.user;
+
+import com.loopers.domain.user.UserEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserJpaRepository extends JpaRepository<UserEntity, String> {
+    boolean existsByUserId(String userId);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1ApiSpec.java
@@ -1,0 +1,23 @@
+package com.loopers.interfaces.api.point;
+
+import com.loopers.interfaces.api.ApiResponse;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name ="Point V1 API")
+public interface PointV1ApiSpec {
+
+    ApiResponse<PointV1Dto.PointResponse> getPoint(
+            @Schema(name = "유저 ID", description = "포인트를 조회할 유저의 ID")
+            String userId
+    );
+
+    @PostMapping("/charge")
+    ApiResponse<PointV1Dto.PointResponse> charge(
+            @Schema(name = "X-USER-ID") String userId,
+            @RequestBody PointV1Dto.PointChargeRequest request
+    );
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1Controller.java
@@ -1,0 +1,47 @@
+package com.loopers.interfaces.api.point;
+
+import com.loopers.application.point.PointFacade;
+import com.loopers.application.point.PointInfo;
+import com.loopers.interfaces.api.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/points")
+public class PointV1Controller implements PointV1ApiSpec{
+
+    private final PointFacade pointFacade;
+
+    @GetMapping
+    @Override
+    public ApiResponse<PointV1Dto.PointResponse> getPoint(
+            @RequestHeader(value = "X-USER-ID")
+            String userId
+    ){
+        if(userId == null || userId.isBlank()){
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "userId is required");
+        }
+        Optional<PointInfo> info = pointFacade.getPointInfo(userId);
+
+        PointV1Dto.PointResponse response = PointV1Dto.PointResponse.from(info);
+        return ApiResponse.success(response);
+    }
+
+    @PostMapping("/charge")
+    @Override
+    public ApiResponse<PointV1Dto.PointResponse> charge(
+            @RequestHeader(value = "X-USER-ID") String userId,
+            @RequestBody PointV1Dto.PointChargeRequest request
+    ){
+
+    PointInfo updatedPoint = pointFacade.chargePoint(userId, request.amount());
+    PointV1Dto.PointResponse response = PointV1Dto.PointResponse.from(Optional.ofNullable(updatedPoint));
+    return ApiResponse.success(response);
+        }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1Dto.java
@@ -1,0 +1,24 @@
+package com.loopers.interfaces.api.point;
+
+import com.loopers.application.point.PointInfo;
+
+import java.util.Optional;
+
+public class PointV1Dto {
+    public record PointResponse(int balance) {
+        public static PointResponse from(Optional<PointInfo> pointInfo) {
+            return new PointResponse(
+                    pointInfo.get().balance()
+            );
+        }
+    }
+
+    public record PointChargeRequest(int amount) {
+        public PointChargeRequest {
+            if (amount <= 0) {
+                throw new IllegalArgumentException("충전 금액은 0보다 커야 합니다.");
+            }
+        }
+
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1ApiSpec.java
@@ -1,0 +1,20 @@
+package com.loopers.interfaces.api.user;
+
+import com.loopers.interfaces.api.ApiResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name ="User V1 API")
+public interface UserV1ApiSpec {
+
+    @Operation(summary = "회원 가입")
+    ApiResponse<UserV1Dto.UserResponse> signUp(
+            UserV1Dto.SignUpRequest signUpRequest
+    );
+    ApiResponse<UserV1Dto.UserInfoResponse> getUserInfo(
+            @Schema(name = "유저Id", description = "조회할 유저의 ID")
+            String userId
+    );
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Controller.java
@@ -1,0 +1,48 @@
+package com.loopers.interfaces.api.user;
+
+
+import com.loopers.application.user.UserFacade;
+import com.loopers.application.user.UserInfo;
+import com.loopers.interfaces.api.ApiResponse;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/users")
+public class UserV1Controller implements UserV1ApiSpec {
+
+    private final UserFacade userFacade;
+
+    @PostMapping
+    @Override
+    public ApiResponse<UserV1Dto.UserResponse> signUp(
+            @RequestBody UserV1Dto.SignUpRequest signUpRequest
+    ){
+        if(signUpRequest.gender() == null){
+            throw new CoreException(ErrorType.BAD_REQUEST,"성별은 필수 입력값 입니다.");
+        }
+        return ApiResponse.success(
+                new UserV1Dto.UserResponse(
+                        "jinnie",
+                        "지은",
+                        "F",
+                        "1997-01-27",
+                        "jinnie@naver.com"
+                )
+        );
+    }
+
+    @GetMapping("/{userId}")
+    @Override
+    public ApiResponse<UserV1Dto.UserInfoResponse> getUserInfo(
+            @PathVariable(value = "userId") String userId
+    ) {
+        UserInfo info = userFacade.getUserInfo(userId);
+        UserV1Dto.UserInfoResponse response = UserV1Dto.UserInfoResponse.from(info);
+        return ApiResponse.success(response);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Dto.java
@@ -1,0 +1,40 @@
+package com.loopers.interfaces.api.user;
+
+import com.loopers.application.user.UserInfo;
+import jakarta.validation.constraints.NotNull;
+
+public class UserV1Dto {
+    public record SignUpRequest(
+            @NotNull
+            String userId,
+            @NotNull
+            String name,
+            @NotNull
+            String gender,
+            @NotNull
+            String birth,
+            @NotNull
+            String email
+    ){
+        public SignUpRequest{
+        }
+    }
+
+    public record UserResponse(
+            String userId,
+            String name,
+            String gender,
+            String birth,
+            String email
+    ){}
+
+    public record UserInfoResponse(String id, String name, String email) {
+        public static UserV1Dto.UserInfoResponse from(UserInfo info) {
+            return new UserV1Dto.UserInfoResponse(
+                    info.userId(),
+                    info.name(),
+                    info.email()
+            );
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/point/PointServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/point/PointServiceIntegrationTest.java
@@ -1,0 +1,99 @@
+package com.loopers.domain.point;
+
+import com.loopers.domain.user.UserEntity;
+
+import com.loopers.infrastructure.point.PointJpaRepository;
+import com.loopers.infrastructure.user.UserJpaRepository;
+import com.loopers.support.error.CoreException;
+import com.loopers.utils.DatabaseCleanUp;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@SpringBootTest
+@Transactional
+@DisplayName("PointService 통합 테스트")
+public class PointServiceIntegrationTest {
+    /*
+     * 포인트 조회 통합 테스트
+     * - [x]  해당 ID 의 회원이 존재할 경우, 보유 포인트가 반환된다.
+     * - [x]  해당 ID 의 회원이 존재하지 않을 경우, null 이 반환된다.
+     *
+     * 포인트 충전 통합 테스트
+     * - [ ] 존재하지 않는 유저 ID로 충전을 시도한 경우, 실패한다.
+     */
+
+    @Autowired
+    private PointService pointService;
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+    @Autowired
+    private PointJpaRepository pointJpaRepository;
+    @Autowired
+    private UserJpaRepository userJpaRepository;
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @Nested
+    class Get {
+        @DisplayName("해당 ID 의 회원이 존재할 경우, 보유 포인트가 반환된다.")
+        @Test
+        void returnsPoint_whenValidIdIsProvided() {
+            // arrange
+            UserEntity userEntity = userJpaRepository.save(
+                    new UserEntity("jinnie", "지은", "F", "1997-01-27", "jinnie@naver.com")
+            );
+            PointEntity pointEntity = pointJpaRepository.save(new PointEntity(1000, userEntity.getUserId()));
+
+            // act
+            Optional<PointEntity> point = pointService.getPoint(userEntity.getUserId());
+
+            // assert
+            assertAll(
+                    () -> assertThat(point).isNotNull(),
+                    () -> assertThat(point.get().getBalance()).isEqualTo(pointEntity.getBalance()),
+                    () -> assertThat(point.get().getUserId()).isEqualTo(pointEntity.getUserId())
+            );
+        }
+
+        @DisplayName("해당 ID 의 회원이 존재하지 않을 경우, null 이 반환된다.")
+        @Test
+        void returnsNull_whenInvalidIdIsProvided() {
+            // arrange
+            String invalidId = "non_existent_user";
+
+            // act
+            Optional<PointEntity> point = pointService.getPoint(invalidId);
+
+            // assert
+            assertThat(point).isEmpty();
+        }
+    }
+
+    @Nested
+    class Charge {
+        @DisplayName("존재하지 않는 유저 ID로 충전을 시도한 경우, 실패한다.")
+        @Test
+        void fail_whenUserDoesNotExistOnCharge() {
+            // arrange
+            String invalidId = "non_existent_user";
+
+            // assert
+            assertThatThrownBy(() -> pointService.chargePoint(invalidId, 1000))
+                    .isInstanceOf(CoreException.class);
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/point/PointTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/point/PointTest.java
@@ -1,0 +1,52 @@
+package com.loopers.domain.point;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class PointTest {
+    /*
+    * 단위 테스트
+    - [x]  0 이하의 정수로 포인트를 충전시 실패한다.
+     */
+    @DisplayName("0 이하의 정수로 포인트를 충전시 실패한다.")
+    @Test
+    void fail_whenChargeAmountIsZeroOrNegative(){
+        //arrange
+        PointEntity pointEntity = new PointEntity(1000, "jinnie");
+
+        //act
+        assertThatThrownBy(() -> pointEntity.increase(0))
+                .isInstanceOf(CoreException.class)
+                .extracting("errorType")
+                .isEqualTo(ErrorType.BAD_REQUEST);
+
+        assertThatThrownBy(() -> pointEntity.increase(-100))
+                .isInstanceOf(CoreException.class)
+                .extracting("errorType")
+                .isEqualTo(ErrorType.BAD_REQUEST);
+    }
+
+    @DisplayName("0 이하의 정수로 포인트를 차감시 실패한다.")
+    @Test
+    void fail_whenDecreaseAmountIsZeroOrNegative(){
+        //arrange
+        PointEntity pointEntity = new PointEntity(1000, "jinnie");
+
+        //act
+        assertThatThrownBy(() -> pointEntity.decrease(0))
+                .isInstanceOf(CoreException.class)
+                .extracting("errorType")
+                .isEqualTo(ErrorType.BAD_REQUEST);
+
+        assertThatThrownBy(() -> pointEntity.decrease(-100))
+                .isInstanceOf(CoreException.class)
+                .extracting("errorType")
+                .isEqualTo(ErrorType.BAD_REQUEST);
+    }
+}
+

--- a/apps/commerce-api/src/test/java/com/loopers/domain/user/UserServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/user/UserServiceIntegrationTest.java
@@ -1,0 +1,129 @@
+package com.loopers.domain.user;
+
+import com.loopers.infrastructure.user.UserJpaRepository;
+import com.loopers.interfaces.api.user.UserV1Dto;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import com.loopers.utils.DatabaseCleanUp;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+
+
+@SpringBootTest
+@Transactional
+@DisplayName("UserService 통합 테스트")
+public class UserServiceIntegrationTest {
+
+    /*
+    * 회원가입 통합 테스트
+    * - [x] 회원 가입시 User 저장이 수행된다. ( spy 검증 )
+    * - [x] 이미 가입된 ID 로 회원가입 시도 시, 실패한다.
+    *
+    * 내 정보 조회 통합 테스트
+    * - [x] 내 정보 조회에 성공할 경우, 해당하는 유저 정보를 응답으로 반환한다.
+    * - [x] 존재하지 않는 ID 로 조회할 경우, 404 Not Found 응답을 반환한다.
+    */
+
+    @Autowired
+    private UserService userService;
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+    @MockitoSpyBean
+    private UserJpaRepository userJpaRepository;
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @DisplayName("회원 가입 시")
+    @Nested
+    class SignUp {
+        @DisplayName("회원 가입시 User 저장이 수행된다. (spy 검증)")
+        @Test
+        void saveUser_whenSignUp() {
+            // arrange
+            UserV1Dto.SignUpRequest signUpRequest = new UserV1Dto.SignUpRequest(
+                    "jinnie", "지은", "F", "1997-01-27", "jinnie@naver.com"
+            );
+            // act
+            UserV1Dto.UserResponse userResponse = userService.signUp(signUpRequest);
+
+            //assert
+            verify(userJpaRepository).save(any(UserEntity.class));
+
+            assertAll(
+                    () -> assertThat(userResponse).isNotNull(),
+                    () -> assertThat(userResponse.userId()).isEqualTo(signUpRequest.userId()),
+                    () -> assertThat(userResponse.name()).isEqualTo(signUpRequest.name()),
+                    () -> assertThat(userResponse.email()).isEqualTo(signUpRequest.email())
+            );
+        }
+
+        @DisplayName("이미 가입된 ID 로 회원가입 시도 시, 실패한다.")
+        @Test
+        void throwsException_whenIdIsAlreadyExists() {
+
+            // arrange
+            UserV1Dto.SignUpRequest signUpRequest = new UserV1Dto.SignUpRequest(
+                    "jinnie", "지은","F", "1997-01-27", "jinnie@naver.com"
+            );
+            userService.signUp(signUpRequest);
+            // act
+            CoreException exception = assertThrows(CoreException.class, () -> {
+                userService.signUp(signUpRequest);  // 같은 ID로 재가입 시도
+            });
+            //assert
+            assertThat(exception.getErrorType()).isEqualTo(ErrorType.CONFLICT);
+        }
+    }
+
+    @DisplayName("회원 정보를 조회할 때, ")
+    @Nested
+    class Get {
+        @DisplayName("해당 ID 의 회원이 존재할 경우, 회원 정보가 반환된다.")
+        @Test
+        void returnsUserInfo_whenValidIdIsProvided() {
+            // arrange
+            UserEntity userEntity = userJpaRepository.save(
+                    new UserEntity("jinnie","지은","F","1997-01-27", "jinnie@naver.com")
+            );
+            // act
+            UserEntity result = userService.getUserEntity(userEntity.getUserId());
+
+            // assert
+            assertAll(
+                    () -> assertThat(result).isNotNull(),
+                    () -> assertThat(result.getUserId()).isEqualTo(userEntity.getUserId()),
+                    () -> assertThat(result.getName()).isEqualTo(userEntity.getName()),
+                    () -> assertThat(result.getEmail()).isEqualTo(userEntity.getEmail())
+            );
+        }
+
+        @DisplayName("해당 ID 의 회원이 존재하지 않을 경우, null 이 반환된다.")
+        @Test
+        void throwsException_whenInvalidIdIsProvided() {
+            // arrange
+            String invalidId = "jin";
+
+            // act
+            CoreException exception = assertThrows(CoreException.class, () -> {
+                userService.getUserEntity(invalidId);
+            });
+
+            // assert
+            assertThat(exception.getErrorType()).isEqualTo(ErrorType.NOT_FOUND);
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/user/UserTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/user/UserTest.java
@@ -1,0 +1,100 @@
+package com.loopers.domain.user;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class UserTest {
+
+    /*
+    * 단위 테스트
+    - [x]  ID 가 `영문 및 숫자 10자 이내` 형식에 맞지 않으면, User 객체 생성에 실패한다.
+    - [x]  이메일이 `xx@yy.zz` 형식에 맞지 않으면, User 객체 생성에 실패한다.
+    - [x]  생년월일이 `yyyy-MM-dd` 형식에 맞지 않으면, User 객체 생성에 실패한다.
+     */
+    @DisplayName("ID 가 `영문 및 숫자 10자 이내` 형식에 맞지 않으면, User 객체 생성에 실패한다.")
+    @ParameterizedTest
+    @ValueSource(strings ={
+            "지은",
+            "지지지지지지은은은은은",
+            "jinn____ie",
+            "12341234123",
+            ""
+    })
+    void fail_whenIdFormatIsInvalid(String userId){
+        // arrange
+        final String name = "지은";
+        final String email = "jinnie@naver.com";
+        final String birth = "1997-01-27";
+        final String gender = "F";
+
+        // act
+        var exception = assertThrows(CoreException.class, () -> {
+            new UserEntity(
+                    userId,
+                    name,
+                    email,
+                    birth,
+                    gender
+            );
+        });
+        // assert
+        assertThat(exception.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+
+    }
+
+    @DisplayName("이메일이 `xx@yy.zz` 형식에 맞지 않으면, User 객체 생성에 실패한다.")
+    @Test
+    void fail_whenNameFormatIsInvalid(){
+        //arrange
+        final String userId = "jinnie";
+        final String name = "지은";
+        final String email = "jinnie@naver";
+        final String birth = "1997-01-27";
+        final String gender = "F";
+
+        //act
+        final CoreException exception = assertThrows(CoreException.class, () -> {
+            new UserEntity(
+                    userId,
+                    name,
+                    email,
+                    birth,
+                    gender
+            );
+        });
+        //assert
+        assertThat(exception.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+
+    }
+
+    @DisplayName("생년월일이 `yyyy-MM-dd` 형식에 맞지 않으면, User 객체 생성에 실패한다.")
+    @Test
+    void fail_whenBirthDateFormatIsInvalid(){
+        //arrange
+        final String userId = "jinnie";
+        final String name = "지은";
+        final String email = "jinnie@naver";
+        final String birth = "1997-01";
+        final String gender = "F";
+
+        //act
+        final CoreException exception = assertThrows(CoreException.class, () -> {
+            new UserEntity(
+                    userId,
+                    name,
+                    email,
+                    birth,
+                    gender
+            );
+        });
+        //assert
+        assertThat(exception.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/api/point/PointV1ApiE2ETest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/api/point/PointV1ApiE2ETest.java
@@ -1,0 +1,161 @@
+package com.loopers.interfaces.api.point;
+
+import com.loopers.domain.point.PointEntity;
+import com.loopers.domain.user.UserEntity;
+import com.loopers.infrastructure.point.PointJpaRepository;
+import com.loopers.infrastructure.user.UserJpaRepository;
+import com.loopers.interfaces.api.ApiResponse;
+
+import com.loopers.utils.DatabaseCleanUp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.*;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class PointV1ApiE2ETest {
+    /*
+     * 포인트 조회 E2E 테스트
+     * - [x] 포인트 조회에 성공할 경우, 보유 포인트를 응답으로 반환한다.
+     * - [x] X-USER-ID 헤더가 없을 경우, 400 Bad Request 응답을 반환한다.
+     *
+     * 포인트 충전 E2E 테스트
+     * - [] 존재하는 유저가 1000원을 충전할 경우, 충전된 보유 총량을 응답으로 반환한다.
+     * - [] 존재하지 않는 유저로 요청할 경우, 404 Not Found 응답을 반환한다.
+     */
+    private final TestRestTemplate testRestTemplate;
+    private final UserJpaRepository userJpaRepository;
+    private final PointJpaRepository pointJpaRepository;
+    private final DatabaseCleanUp databaseCleanUp;
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+    @Autowired
+    public PointV1ApiE2ETest(TestRestTemplate testRestTemplate, UserJpaRepository userJpaRepository, PointJpaRepository pointJpaRepository, DatabaseCleanUp databaseCleanUp) {
+        this.testRestTemplate = testRestTemplate;
+        this.userJpaRepository = userJpaRepository;
+        this.pointJpaRepository = pointJpaRepository;
+        this.databaseCleanUp = databaseCleanUp;
+    }
+
+    @DisplayName("GET /api/v1/points/{userId}")
+    @Nested
+    class getPoint {
+
+        private static final String ENDPOINT = "/api/v1/points";
+
+        @DisplayName("포인트 조회에 성공할 경우, 보유 포인트를 응답으로 반환한다.")
+        @Test
+        void returnsPoint_whenValidUserIdIsProvided() {
+
+            //arrange
+            UserEntity userEntity = new UserEntity("jinnie", "지은", "F", "1997-01-27", "jinnie@naver.com");
+            userJpaRepository.save(userEntity);
+
+            PointEntity pointEntity = new PointEntity(1000,userEntity.getUserId());
+            pointJpaRepository.save(pointEntity);
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.add("X-USER-ID", userEntity.getUserId());
+            HttpEntity<Object> requestEntity = new HttpEntity<>(headers);
+
+            //act
+            ParameterizedTypeReference<ApiResponse<PointV1Dto.PointResponse>> responseType = new ParameterizedTypeReference<>() {};
+            ResponseEntity<ApiResponse<PointV1Dto.PointResponse>> response =
+                    testRestTemplate.exchange(ENDPOINT, HttpMethod.GET, requestEntity, responseType);
+
+            //assert
+            assertAll(
+                    () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK),
+                    () -> assertThat(response.getBody().data().balance()).isEqualTo(pointEntity.getBalance())
+            );
+
+        }
+
+        @DisplayName("X-USER-ID 헤더가 없을 경우, 400 Bad Request 응답을 반환한다.")
+        @Test
+        void returnsBadRequest_whenXUserIdHeaderIsMissing() {
+
+            //arrange
+            HttpEntity<?> requestEntity = new HttpEntity<>(null);
+
+            //act
+            ParameterizedTypeReference<ApiResponse<PointV1Dto.PointResponse>> responseType = new ParameterizedTypeReference<>() {};
+            ResponseEntity<ApiResponse<PointV1Dto.PointResponse>> response =
+                    testRestTemplate.exchange(ENDPOINT, HttpMethod.GET, requestEntity, responseType);
+
+            //assert
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+
+        }
+    }
+
+    @DisplayName("GET /api/v1/points/{userId}")
+    @Nested
+    class chargePoint {
+
+        private static final String ENDPOINT_POST = "/api/v1/points/charge";
+
+        @DisplayName("존재하는 유저가 1000원을 충전할 경우, 충전된 보유 총량을 응답으로 반환한다.")
+        @Test
+        void returnsUpdatedBalance_whenUserCharges1000() {
+            //arrange
+            UserEntity userEntity = new UserEntity("jinnie", "지은", "F", "1997-01-27", "jinnie@naver.com");
+            userJpaRepository.save(userEntity);
+            pointJpaRepository.save(new PointEntity(1000,userEntity.getUserId()));
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.add("X-USER-ID", userEntity.getUserId());
+            headers.setContentType(MediaType.APPLICATION_JSON);
+
+            PointV1Dto.PointChargeRequest request = new PointV1Dto.PointChargeRequest(1000);
+            HttpEntity<PointV1Dto.PointChargeRequest> requestEntity = new HttpEntity<>(request, headers);
+
+            //act
+            ParameterizedTypeReference<ApiResponse<PointV1Dto.PointResponse>> responseType = new ParameterizedTypeReference<>() {};
+            ResponseEntity<ApiResponse<PointV1Dto.PointResponse>> response = testRestTemplate.exchange(ENDPOINT_POST, HttpMethod.POST, requestEntity, responseType);
+
+            //assert
+            assertAll(
+                    () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK),
+                    () -> assertThat(response.getBody()).isNotNull(),
+                    () -> assertThat(response.getBody().data().balance()).isEqualTo(2000)
+            );
+        }
+
+        @DisplayName("존재하지 않는 유저로 요청할 경우, 404 Not Found 응답을 반환한다.")
+        @Test
+        void returnsNotFound_whenUserDoesNotExist() {
+            //arrange
+            HttpHeaders headers = new HttpHeaders();
+            headers.set("X-USER-ID", "non_existent_user");
+            headers.setContentType(MediaType.APPLICATION_JSON);
+
+            PointV1Dto.PointChargeRequest request = new PointV1Dto.PointChargeRequest(1000);
+            HttpEntity<PointV1Dto.PointChargeRequest> requestEntity = new HttpEntity<>(request, headers);
+
+            //act
+            ParameterizedTypeReference<ApiResponse<PointV1Dto.PointResponse>> responseType = new ParameterizedTypeReference<>() {};
+            ResponseEntity<ApiResponse<PointV1Dto.PointResponse>> response = testRestTemplate.exchange(ENDPOINT_POST, HttpMethod.POST, requestEntity, responseType);
+
+            //assert
+            assertAll(
+                    () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND),
+                    () -> assertThat(response.getBody()).isNotNull(),
+                    () -> assertThat(response.getBody().meta().result()).isEqualTo(ApiResponse.Metadata.Result.FAIL),
+                    () -> assertThat(response.getBody().data()).isNull()
+            );
+        }
+    }
+    }

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/api/user/UserV1ApiE2ETest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/api/user/UserV1ApiE2ETest.java
@@ -1,0 +1,152 @@
+package com.loopers.interfaces.api.user;
+
+import com.loopers.domain.user.UserEntity;
+import com.loopers.infrastructure.user.UserJpaRepository;
+import com.loopers.interfaces.api.ApiResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.function.Function;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class UserV1ApiE2ETest {
+    /*
+     * 회원가입 E2E 테스트
+     * - [x] 회원 가입이 성공할 경우, 생성된 유저 정보를 응답으로 반환한다.
+     * - [x] 회원 가입 시에 성별이 없을 경우, 400 Bad Request 응답을 반환한다.
+     *
+     * 내 정보 조회 E2E 테스트
+     * - [x] 내 정보 조회에 성공할 경우, 해당하는 유저 정보를 응답으로 반환한다.
+     * - [x] 존재하지 않는 ID 로 조회할 경우, 404 Not Found 응답을 반환한다.
+     */
+
+    private final TestRestTemplate testRestTemplate;
+    private final UserJpaRepository userJpaRepository;
+
+    @Autowired
+    public UserV1ApiE2ETest(TestRestTemplate testRestTemplate, UserJpaRepository userJpaRepository) {
+        this.testRestTemplate = testRestTemplate;
+        this.userJpaRepository = userJpaRepository;
+    }
+
+    @DisplayName("POST /api/v1/users")
+    @Nested
+    class Join {
+        private static final String ENDPOINT = "/api/v1/users";
+
+        @DisplayName("회원 가입이 성공할 경우, 생성된 유저 정보를 응답으로 반환한다.")
+        @Test
+        void returnsUserInfo_whenJoinIsSuccessful() {
+
+            //arrange
+            UserV1Dto.SignUpRequest signUpRequest = new UserV1Dto.SignUpRequest(
+                    "jinnie",
+                    "지은",
+                    "F",
+                    "1997-01-27",
+                    "jinnie@naver.com"
+            );
+
+            //act
+            ParameterizedTypeReference<ApiResponse<UserV1Dto.UserResponse>> responseType = new ParameterizedTypeReference<>() {};
+            ResponseEntity<ApiResponse<UserV1Dto.UserResponse>> response =
+                    testRestTemplate.exchange(ENDPOINT, HttpMethod.POST, new HttpEntity<>(signUpRequest), responseType);
+
+            //assert
+            assertAll(
+                    () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK),
+                    () -> assertThat(response.getBody()).isNotNull(),
+                    () -> assertThat(response.getBody().data().name()).isEqualTo(signUpRequest.name()),
+                    () -> assertThat(response.getBody().data().gender()).isEqualTo(signUpRequest.gender())
+            );
+        }
+
+        @DisplayName("회원 가입 시에 성별이 없을 경우, 400 Bad Request 응답을 반환한다.")
+        @Test
+        void returnsBadRequest_whenGenderIsMissing() {
+
+            //arrange
+            UserV1Dto.SignUpRequest signUpRequest = new UserV1Dto.SignUpRequest(
+                    "jinnie",
+                    "지은",
+                    null,
+                    "1997-01-27",
+                    "jinnie@naver.com"
+
+            );
+            //act
+            ParameterizedTypeReference<ApiResponse<UserV1Dto.UserResponse>> responseType = new ParameterizedTypeReference<>() {};
+            ResponseEntity<ApiResponse<UserV1Dto.UserResponse>> response =
+                    testRestTemplate.exchange(ENDPOINT, HttpMethod.POST, new HttpEntity<>(signUpRequest), responseType);
+
+            //assert
+            assertAll(
+                    () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST),
+                    () -> assertThat(response.getBody().meta().result()).isEqualTo(ApiResponse.Metadata.Result.FAIL),
+                    () -> assertThat(response.getBody().data()).isNull()
+            );
+        }
+    }
+
+    @DisplayName("GET /api/v1/users/{id}")
+    @Nested
+    class getUserInfo {
+
+        private static final Function<String,String> ENDPOINT_GET = id -> "/api/v1/users/" + id;
+
+        @DisplayName("내 정보 조회에 성공할 경우, 해당하는 유저 정보를 응답으로 반환한다.")
+        @Test
+        void returnsUserInfo_whenGetUserInfoIsSuccessful() {
+
+            //arrange
+            UserEntity userEntity = new UserEntity("jinnie","지은","F","1997-01-27", "jinnie@naver.com");
+            userJpaRepository.save(userEntity);
+
+            String requestUrl = ENDPOINT_GET.apply(userEntity.getUserId());
+
+            //act
+            ParameterizedTypeReference<ApiResponse<UserV1Dto.UserResponse>> responseType = new ParameterizedTypeReference<>() {};
+            ResponseEntity<ApiResponse<UserV1Dto.UserResponse>> response =
+                    testRestTemplate.exchange(requestUrl, HttpMethod.GET, new HttpEntity<>(null), responseType);
+
+            //assert
+            assertAll(
+                    () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK),
+                    () -> assertThat(response.getBody()).isNotNull(),
+                    () -> assertThat(response.getBody().data().name()).isEqualTo(userEntity.getName())
+            );
+        }
+
+        @DisplayName("존재하지 않는 ID 로 조회할 경우, 404 Not Found 응답을 반환한다.")
+        @Test
+        void returnsBadRequest_whenGetUserInfoIsNotFound() {
+            //arrange
+            String userId = "non_existent_user";
+            String requestUrl = ENDPOINT_GET.apply(userId);
+
+            //act
+            ParameterizedTypeReference<ApiResponse<UserV1Dto.UserResponse>> responseType = new ParameterizedTypeReference<>() {};
+            ResponseEntity<ApiResponse<UserV1Dto.UserResponse>> response =
+                    testRestTemplate.exchange(requestUrl, HttpMethod.GET, new HttpEntity<>(null), responseType);
+
+            //assert
+            assertAll(
+                    () -> assertTrue(response.getStatusCode().is4xxClientError()),
+                    () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND)
+            );
+        }
+    }
+}


### PR DESCRIPTION
## 📌 Summary 
 - 회원가입 기능 구현, 테스트
 - 내 정보 조회 기능 구현, 테스트
 - 포인트 조회 기능 구현, 테스트
 - 포인트 충전 기능 구현, 테스트

## 💬 Review Points
1. 계층 구조 (Controller → Facade → Service → Repository)
* 제가 설계한 레이어 분리가 일반적으로 추천되는 패턴과 크게 어긋나지 않는지 궁금합니다.
* 각 계층의 역할을 명확히 구분해야 할까요? (예: Controller=I/O 변환, Facade=유스케이스 조합, Service=도메인 비즈니스, Repository=영속화 등)
* 단일 서비스 호출만 있는 기능에도 Facade를 두는 게 과한가요, 아니면 확장성을 위해 초기에 두는 것이 괜찮은가요?

2. User ↔ Point 관계 설계
* 지금은 단순화를 위해 PointEntity에 userId(문자열 필드)만 두고 JPA 연관관계는 설정하지 않았습니다.
* 향후 1:1 연관관계를 맺도록 바꾸는 게 좋을까요? 아니면 지금처럼 약한 결합을 유지하는 편이 관리에 더 유리한가요?
* 이 결정이 조회 성능, 삭제/정합성 관리, 트랜잭션 설계에 어떤 영향을 주는지 궁금합니다.

3. 테스트 범위와 우선순위
* 과제 요구 사항에 맞는 최소 테스트(E2E/통합 위주)만 작성했습니다.
* 실무에서는 어느 계층까지(엔티티, 서비스, 리포지토리, API 레이어) 테스트를 작성해야 하는지 궁금합니다.
* 실패 케이스나 예외 처리는 어느 정도까지 커버하는 것을 권장하시는지 궁금합니다.

4. Entity ↔ DTO 변환 위치
* 컨트롤러에서 DTO ↔ 도메인 변환을 수행하거나, DTO 내부 from() 정적 팩토리를 사용하였는데 괜찮은 방법일까요?
* 이 책임을 Facade나 Service 쪽으로 옮기거나, 전담 Mapper를 쓰는 게 더 나을까요?

5. 식별자 전략
* UserEntity에서 Long 타입의 Id를 만들지 않고, String userId를 @id로 설정하였는데 실제로 필요한 정보가 아니어도 엔티티를 설계할 때 Long 타입의 ID가 꼭 필요할까요?

6. 예외 처리 일관성
* CoreException, ResponseStatusException 등으로 예외 처리를 하였는데, 예외 처리를 통일하는 것이 좋을까요, 아니면 계층별로 다르게 유지해도 될까요?
* API 응답 포맷(ApiResponse)과 HTTP 상태 코드 전략을 어떻게 정하는 게 좋은지 궁금합니다!

## ✅ Checklist
  - [x] 테스트는 모두 통과해야 하며, @Test 기반으로 명시적으로 작성
  - [x] 각 테스트는 테스트 명/설명/입력/예상 결과가 분명해야 함
  - [x] E2E 테스트는 실제 HTTP 요청을 통해 흐름을 검증할 것
