### PR TITLE
[volume-4] 쿠폰 도메인 구현, 동시성 제어

### DIFF
--- a/apps/commerce-api/build.gradle.kts
+++ b/apps/commerce-api/build.gradle.kts
@@ -1,6 +1,3 @@
-plugins {
-    kotlin("jvm") version "2.1.21"
-}
 dependencies {
     // add-ons
     implementation(project(":modules:jpa"))
@@ -20,12 +17,4 @@ dependencies {
 
     // test-fixtures
     testImplementation(testFixtures(project(":modules:jpa")))
-    implementation(kotlin("stdlib-jdk8"))
-    testImplementation(kotlin("test"))
-}
-repositories {
-    mavenCentral()
-}
-kotlin {
-    jvmToolchain(21)
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/coupon/CouponFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/coupon/CouponFacade.java
@@ -15,7 +15,6 @@ public class CouponFacade {
     private final UserCouponService userCouponService;
 
     public long applyCoupon(UserCouponCommand.Apply command) {
-        userCouponService.validateOwnedAndUnused(new UserCouponCommand.Use(command.userId(), command.couponId()));
 
         CouponEntity coupon = couponService.getAvailableCoupon(command.couponId());
         long discountedPrice = couponService.applyDiscount(coupon, command.originalPrice());

--- a/apps/commerce-api/src/main/java/com/loopers/application/coupon/CouponFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/coupon/CouponFacade.java
@@ -20,6 +20,8 @@ public class CouponFacade {
         CouponEntity coupon = couponService.getAvailableCoupon(command.couponId());
         long discountedPrice = couponService.applyDiscount(coupon, command.originalPrice());
 
+        coupon.markAsUsed();
+
         userCouponService.useCoupon(new UserCouponCommand.Use(command.userId(), command.couponId()));
         return discountedPrice;
     }

--- a/apps/commerce-api/src/main/java/com/loopers/application/coupon/CouponFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/coupon/CouponFacade.java
@@ -1,0 +1,26 @@
+package com.loopers.application.coupon;
+
+import com.loopers.domain.coupon.CouponEntity;
+import com.loopers.domain.coupon.CouponService;
+import com.loopers.domain.userCoupon.UserCouponCommand;
+import com.loopers.domain.userCoupon.UserCouponService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class CouponFacade {
+
+    private final CouponService couponService;
+    private final UserCouponService userCouponService;
+
+    public long applyCoupon(UserCouponCommand.Apply command) {
+        userCouponService.validateOwnedAndUnused(new UserCouponCommand.Use(command.userId(), command.couponId()));
+
+        CouponEntity coupon = couponService.getAvailableCoupon(command.couponId());
+        long discountedPrice = couponService.applyDiscount(coupon, command.originalPrice());
+
+        userCouponService.useCoupon(new UserCouponCommand.Use(command.userId(), command.couponId()));
+        return discountedPrice;
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/like/LikeFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/like/LikeFacade.java
@@ -3,6 +3,7 @@ package com.loopers.application.like;
 import com.loopers.domain.product.ProductInfo;
 import com.loopers.domain.like.LikeService;
 import com.loopers.domain.product.ProductService;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -11,6 +12,7 @@ import java.util.List;
 
 @RequiredArgsConstructor
 @Component
+@Transactional
 public class LikeFacade {
     private final LikeService likeService;
     private final ProductService productService;

--- a/apps/commerce-api/src/main/java/com/loopers/application/like/LikeFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/like/LikeFacade.java
@@ -3,20 +3,20 @@ package com.loopers.application.like;
 import com.loopers.domain.product.ProductInfo;
 import com.loopers.domain.like.LikeService;
 import com.loopers.domain.product.ProductService;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 
 @RequiredArgsConstructor
 @Component
-@Transactional
 public class LikeFacade {
     private final LikeService likeService;
     private final ProductService productService;
 
+    @Transactional(readOnly = true)
     public List<ProductInfo> getLikedProducts(long userId){
         return likeService.getLikesByUserId(userId).stream()
                 .map(like -> productService.getProduct(like.productId()))

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderFacade.java
@@ -1,10 +1,16 @@
 package com.loopers.application.order;
 
+import com.loopers.domain.coupon.CouponEntity;
+import com.loopers.domain.coupon.CouponService;
 import com.loopers.domain.order.OrderCommand;
 import com.loopers.domain.order.OrderInfo;
 import com.loopers.domain.order.OrderService;
 import com.loopers.domain.point.PointService;
 import com.loopers.domain.product.ProductService;
+import com.loopers.domain.userCoupon.UserCouponCommand;
+import com.loopers.domain.userCoupon.UserCouponService;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,21 +20,45 @@ import org.springframework.transaction.annotation.Transactional;
 public class OrderFacade {
 
     private final OrderService orderService;
-    private final ProductService productService;
     private final PointService pointService;
+    private final UserCouponService userCouponService;
+    private final ProductService productService;
+    private final CouponService couponService;
 
     @Transactional
     public OrderInfo createOrder(OrderCommand.Order command) {
-
+        // 총 상품 금액 계산
+        long totalPrice = command.orderItems().stream()
+                .mapToLong(item -> item.price() * item.quantity())
+                .sum();
+        // 재고 차감
         command.orderItems().forEach(item ->
                 productService.decreaseStock(item.productId(), item.quantity()));
 
-        Long totalPrice = command.orderItems().stream()
-                .mapToLong(item -> item.price() * item.quantity())
-                .sum();
+        // 쿠폰 할인 적용 (쿠폰 존재 시)
+        long discountedAmount = 0L;
+        if (command.couponId() != null) {
 
-        pointService.usePoints(command.userId(), totalPrice);
+            userCouponService.validateOwnedAndUnused(
+                    new UserCouponCommand.Use(command.userId(), command.couponId())
+            );
 
-        return orderService.createOrder(command);
-    }
+            CouponEntity coupon = couponService.getAvailableCoupon(command.couponId());
+
+            discountedAmount = couponService.applyDiscount(coupon, totalPrice);
+
+            userCouponService.useCoupon(
+                    new UserCouponCommand.Use(command.userId(), command.couponId())
+            );
+        }
+            // 최종 결제 금액 = 총액 - 할인
+            long finalPayablePrice = totalPrice - discountedAmount;
+            if (finalPayablePrice < 0) {
+                throw new CoreException(ErrorType.BAD_REQUEST, "결제 금액이 0보다 작을 수 없습니다.");
+            }
+            pointService.usePoints(command.userId(), totalPrice);
+
+            return orderService.createOrder(command);
+        }
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderFacade.java
@@ -39,10 +39,6 @@ public class OrderFacade {
         long discountedAmount = 0L;
         if (command.couponId() != null) {
 
-            userCouponService.validateOwnedAndUnused(
-                    new UserCouponCommand.Use(command.userId(), command.couponId())
-            );
-
             CouponEntity coupon = couponService.getAvailableCoupon(command.couponId());
 
             discountedAmount = couponService.applyDiscount(coupon, totalPrice);

--- a/apps/commerce-api/src/main/java/com/loopers/domain/brand/BrandEntity.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/brand/BrandEntity.java
@@ -11,6 +11,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class BrandEntity extends BaseEntity {
 
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
     private String name;
 
     private String description;

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponCommand.java
@@ -1,0 +1,9 @@
+package com.loopers.domain.coupon;
+
+import java.time.LocalDateTime;
+
+public class CouponCommand {
+
+    public record Create(String name, DiscountType discountType, LocalDateTime expiredAt) {}
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponCommand.java
@@ -4,6 +4,6 @@ import java.time.LocalDateTime;
 
 public class CouponCommand {
 
-    public record Create(String name, DiscountType discountType, LocalDateTime expiredAt) {}
+    public record Create(String name, DiscountType discountType,Long discountAmount, Double discountRate, LocalDateTime expiredAt) {}
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponEntity.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponEntity.java
@@ -1,0 +1,71 @@
+package com.loopers.domain.coupon;
+
+
+import com.loopers.domain.BaseEntity;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Table(name = "coupons")
+@NoArgsConstructor
+public class CouponEntity extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    private DiscountType disCountType;
+
+    @Enumerated(EnumType.STRING)
+    private CouponStatus couponStatus;
+
+    private Long discountAmount;
+
+    private Double discountRate;
+
+    private LocalDateTime expiredAt;
+
+    private CouponEntity(String name, DiscountType disCountType,  LocalDateTime expiredAt) {
+        if (name == null || name.isBlank()) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "쿠폰 이름은 필수입니다.");
+        }
+        if (disCountType == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "할인 정책은 필수입니다.");
+        }
+        if (couponStatus == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "쿠폰 상태는 필수입니다.");
+        }
+        if (expiredAt == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "쿠폰 만료일은 필수입니다.");
+        }
+        this.name = name;
+        this.disCountType = DiscountType.FIXED_AMOUNT;
+        this.couponStatus = CouponStatus.AVAILABLE;
+        this.expiredAt = expiredAt;
+    }
+    public static CouponEntity of(String name, DiscountType disCountType, LocalDateTime expiredAt) {
+        return new CouponEntity(name, disCountType, expiredAt);
+    }
+
+    public boolean isAvailable() {
+        return CouponStatus.AVAILABLE.equals(this.couponStatus) && this.expiredAt.isBefore(LocalDateTime.now());
+    }
+
+    public long applyDiscount(long originalPrice){
+        if(disCountType == DiscountType.FIXED_AMOUNT){
+            return Math.max(0, originalPrice - discountAmount);
+        }else if(disCountType == DiscountType.FIXED_RATE){
+            return Math.max(0, (long)(originalPrice * (1-discountRate)));
+        }
+        return originalPrice;
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponEntity.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponEntity.java
@@ -45,7 +45,7 @@ public class CouponEntity extends BaseEntity {
             throw new CoreException(ErrorType.BAD_REQUEST, "쿠폰 만료일은 필수입니다.");
         }
         this.name = name;
-        this.disCountType = DiscountType.FIXED_AMOUNT;
+        this.disCountType = disCountType;
         this.couponStatus = CouponStatus.AVAILABLE;
         this.discountAmount = discountAmount;
         this.discountRate = discountRate;

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponEntity.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponEntity.java
@@ -34,15 +34,12 @@ public class CouponEntity extends BaseEntity {
 
     private LocalDateTime expiredAt;
 
-    private CouponEntity(String name, DiscountType disCountType,  LocalDateTime expiredAt) {
+    private CouponEntity(String name, DiscountType disCountType, Long discountAmount, Double discountRate,  LocalDateTime expiredAt) {
         if (name == null || name.isBlank()) {
             throw new CoreException(ErrorType.BAD_REQUEST, "쿠폰 이름은 필수입니다.");
         }
         if (disCountType == null) {
             throw new CoreException(ErrorType.BAD_REQUEST, "할인 정책은 필수입니다.");
-        }
-        if (couponStatus == null) {
-            throw new CoreException(ErrorType.BAD_REQUEST, "쿠폰 상태는 필수입니다.");
         }
         if (expiredAt == null) {
             throw new CoreException(ErrorType.BAD_REQUEST, "쿠폰 만료일은 필수입니다.");
@@ -50,14 +47,24 @@ public class CouponEntity extends BaseEntity {
         this.name = name;
         this.disCountType = DiscountType.FIXED_AMOUNT;
         this.couponStatus = CouponStatus.AVAILABLE;
+        this.discountAmount = discountAmount;
+        this.discountRate = discountRate;
         this.expiredAt = expiredAt;
+
     }
-    public static CouponEntity of(String name, DiscountType disCountType, LocalDateTime expiredAt) {
-        return new CouponEntity(name, disCountType, expiredAt);
+    public static CouponEntity of(String name, DiscountType disCountType, Long discountAmount, Double discountRate, LocalDateTime expiredAt) {
+        return new CouponEntity(name, disCountType, discountAmount, discountRate, expiredAt);
     }
 
     public boolean isAvailable() {
-        return CouponStatus.AVAILABLE.equals(this.couponStatus) && this.expiredAt.isBefore(LocalDateTime.now());
+        return CouponStatus.AVAILABLE.equals(this.couponStatus) && this.expiredAt.isAfter(LocalDateTime.now());
+    }
+
+    public void markAsUsed() {
+        if (this.couponStatus != CouponStatus.AVAILABLE) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "이미 사용된 쿠폰입니다.");
+        }
+        this.couponStatus = CouponStatus.USED;
     }
 
     public long applyDiscount(long originalPrice){

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponInfo.java
@@ -1,0 +1,23 @@
+package com.loopers.domain.coupon;
+
+import java.time.LocalDateTime;
+
+public record CouponInfo (
+
+    Long couponId,
+    String name,
+    DiscountType discountType,
+    CouponStatus status,
+    LocalDateTime expiredAt
+    ){
+    public static CouponInfo from(CouponEntity entity) {
+        return new CouponInfo(
+                entity.getId(),
+                entity.getName(),
+                entity.getDisCountType(),
+                entity.getCouponStatus(),
+                entity.getExpiredAt()
+        );
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponRepository.java
@@ -5,4 +5,5 @@ import java.util.Optional;
 public interface CouponRepository {
     Optional<CouponEntity> findById(Long id);
     CouponEntity save(CouponEntity couponEntity);
+    Optional<CouponEntity> findWithLockById(long id);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponRepository.java
@@ -1,0 +1,8 @@
+package com.loopers.domain.coupon;
+
+import java.util.Optional;
+
+public interface CouponRepository {
+    Optional<CouponEntity> findById(Long id);
+    CouponEntity save(CouponEntity couponEntity);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponService.java
@@ -14,13 +14,13 @@ public class CouponService {
 
     public CouponInfo create(CouponCommand.Create command) {
         CouponEntity coupon = CouponEntity.of(
-                command.name(), command.discountType(),command.expiredAt()
+                command.name(), command.discountType(), command.discountAmount(), command.discountRate(),command.expiredAt()
         );
         return CouponInfo.from(couponRepository.save(coupon));
     }
 
     public CouponEntity getAvailableCoupon(Long couponId) {
-        CouponEntity coupon = couponRepository.findById(couponId)
+        CouponEntity coupon = couponRepository.findWithLockById(couponId)
                 .orElseThrow(() -> new CoreException(NOT_FOUND, "존재하지 않는 쿠폰입니다."));
         if (!coupon.isAvailable()) throw new CoreException(BAD_REQUEST, "사용이 불가한 쿠폰입니다.");
         return coupon;

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponService.java
@@ -3,6 +3,7 @@ package com.loopers.domain.coupon;
 import com.loopers.support.error.CoreException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import static com.loopers.support.error.ErrorType.BAD_REQUEST;
 import static com.loopers.support.error.ErrorType.NOT_FOUND;
@@ -12,6 +13,7 @@ import static com.loopers.support.error.ErrorType.NOT_FOUND;
 public class CouponService {
     private final CouponRepository couponRepository;
 
+    @Transactional
     public CouponInfo create(CouponCommand.Create command) {
         CouponEntity coupon = CouponEntity.of(
                 command.name(), command.discountType(), command.discountAmount(), command.discountRate(),command.expiredAt()
@@ -19,6 +21,7 @@ public class CouponService {
         return CouponInfo.from(couponRepository.save(coupon));
     }
 
+    @Transactional
     public CouponEntity getAvailableCoupon(Long couponId) {
         CouponEntity coupon = couponRepository.findWithLockById(couponId)
                 .orElseThrow(() -> new CoreException(NOT_FOUND, "존재하지 않는 쿠폰입니다."));

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponService.java
@@ -1,0 +1,32 @@
+package com.loopers.domain.coupon;
+
+import com.loopers.support.error.CoreException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import static com.loopers.support.error.ErrorType.BAD_REQUEST;
+import static com.loopers.support.error.ErrorType.NOT_FOUND;
+
+@RequiredArgsConstructor
+@Service
+public class CouponService {
+    private final CouponRepository couponRepository;
+
+    public CouponInfo create(CouponCommand.Create command) {
+        CouponEntity coupon = CouponEntity.of(
+                command.name(), command.discountType(),command.expiredAt()
+        );
+        return CouponInfo.from(couponRepository.save(coupon));
+    }
+
+    public CouponEntity getAvailableCoupon(Long couponId) {
+        CouponEntity coupon = couponRepository.findById(couponId)
+                .orElseThrow(() -> new CoreException(NOT_FOUND, "존재하지 않는 쿠폰입니다."));
+        if (!coupon.isAvailable()) throw new CoreException(BAD_REQUEST, "사용이 불가한 쿠폰입니다.");
+        return coupon;
+    }
+
+    public long applyDiscount(CouponEntity coupon, long price) {
+        return coupon.applyDiscount(price);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponStatus.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponStatus.java
@@ -1,0 +1,7 @@
+package com.loopers.domain.coupon;
+
+public enum CouponStatus {
+    AVAILABLE,
+    USED,
+    EXPIRED
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/DiscountType.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/DiscountType.java
@@ -1,0 +1,6 @@
+package com.loopers.domain.coupon;
+
+public enum DiscountType {
+    FIXED_AMOUNT,
+    FIXED_RATE
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeEntity.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeEntity.java
@@ -5,11 +5,15 @@ import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "likes")
+@Table(
+        name = "likes",
+        uniqueConstraints = @UniqueConstraint(name = "uk_like_user_product", columnNames = {"user_id", "product_id"})
+)
 @Getter
 @NoArgsConstructor
 public class LikeEntity extends BaseEntity {

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeService.java
@@ -24,7 +24,7 @@ public class LikeService {
                     return LikeInfo.from(saved);
                 });
     }
-
+    @Transactional
     public LikeInfo unlike(LikeCommand.Create likeCommand) {
         long userId = likeCommand.userId();
         long productId = likeCommand.productId();

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeService.java
@@ -1,7 +1,6 @@
 package com.loopers.domain.like;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,17 +15,13 @@ public class LikeService {
 
     @Transactional
     public LikeInfo like(LikeCommand.Create cmd) {
-        LikeEntity entity = LikeEntity.of(cmd.userId(), cmd.productId());
-        try {
-            LikeEntity saved = likeRepository.save(entity);
-            return LikeInfo.from(saved);
-        } catch (DataIntegrityViolationException e) {
-
-            return likeRepository.find(cmd.userId(), cmd.productId())
-                    .map(LikeInfo::from)
-                    .orElseGet(() -> LikeInfo.liked(cmd.userId(), cmd.productId()));
+        boolean exists = likeRepository.exists(cmd.userId(), cmd.productId());
+        if (!exists) {
+            likeRepository.save(LikeEntity.of(cmd.userId(), cmd.productId()));
         }
+        return LikeInfo.liked(cmd.userId(), cmd.productId());
     }
+
     @Transactional
     public LikeInfo unlike(LikeCommand.Create likeCommand) {
         likeRepository.deleteByUserIdAndProductId(likeCommand.userId(), likeCommand.productId());

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderCommand.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 public class OrderCommand {
     public record Order(
-            Long userId, List<OrderItem> orderItems
+            Long userId, List<OrderItem> orderItems, Long couponId
     ){}
 
     public record OrderItem(

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderEntity.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderEntity.java
@@ -16,7 +16,7 @@ public class OrderEntity extends BaseEntity {
     @Column(nullable = false)
     private Long userId;
 
-    @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "order", cascade = CascadeType.ALL)
     private final List<OrderItemEntity> orderItems = new ArrayList<>();
 
     private Long totalPrice;

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderItemEntity.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderItemEntity.java
@@ -6,14 +6,16 @@ import jakarta.persistence.*;
 import lombok.Getter;
 
 @Entity
-@Table(name = "order_items")
+@Table(name = "order_item")
 @Getter
 public class OrderItemEntity {
     @Id
+    @Column(name = "order_item_id")
     @GeneratedValue
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id", nullable = false)
     private OrderEntity order;
 
     private Long productId;

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderService.java
@@ -11,7 +11,6 @@ import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Component
-@Transactional
 public class OrderService {
 
     private final OrderRepository orderRepository;

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderService.java
@@ -4,7 +4,6 @@ import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderService.java
@@ -4,12 +4,14 @@ import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Component
+@Transactional
 public class OrderService {
 
     private final OrderRepository orderRepository;

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderService.java
@@ -2,19 +2,19 @@ package com.loopers.domain.order;
 
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 @RequiredArgsConstructor
 @Component
-@Transactional
 public class OrderService {
 
     private final OrderRepository orderRepository;
 
+    @Transactional
     public OrderInfo createOrder(OrderCommand.Order orderCommand) {
         List<OrderItemEntity> items = orderCommand.orderItems().stream()
                 .map(item -> OrderItemEntity.of(item.productId(), item.quantity(), item.price()))
@@ -24,6 +24,7 @@ public class OrderService {
         return OrderInfo.from(saved);
     }
 
+    @Transactional(readOnly = true)
     public List<OrderInfo> getOrders(Long userId) {
         var orders = orderRepository.findByUserId(userId);
         return orders.stream()
@@ -31,6 +32,7 @@ public class OrderService {
                 .toList();
     }
 
+    @Transactional(readOnly = true)
     public OrderInfo getOrder(Long orderId) {
         OrderEntity orderEntity = orderRepository.findById(orderId)
                 .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND));

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderService.java
@@ -2,14 +2,15 @@ package com.loopers.domain.order;
 
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Component
+@Transactional
 public class OrderService {
 
     private final OrderRepository orderRepository;
@@ -24,10 +25,10 @@ public class OrderService {
     }
 
     public List<OrderInfo> getOrders(Long userId) {
-        List<OrderEntity> orderEntities = orderRepository.findByUserId(userId);
-
-        return orderEntities.stream().map(OrderInfo::from).collect(Collectors.toList());
-
+        var orders = orderRepository.findByUserId(userId);
+        return orders.stream()
+                .map(OrderInfo::from)
+                .toList();
     }
 
     public OrderInfo getOrder(Long orderId) {

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/PointEntity.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/PointEntity.java
@@ -1,5 +1,6 @@
 package com.loopers.domain.point;
 
+import com.loopers.domain.BaseEntity;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import jakarta.persistence.*;
@@ -10,13 +11,16 @@ import lombok.NoArgsConstructor;
 @Table(name = "points")
 @Getter
 @NoArgsConstructor
-public class PointEntity {
+public class PointEntity extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private Long balance;
+
+    @Version
+    private Long version;
 
     @Column(name = "user_id", nullable = false)
     private Long userId;
@@ -41,7 +45,7 @@ public class PointEntity {
             throw new CoreException(ErrorType.BAD_REQUEST);
         }
         if(this.balance < amount){
-            throw new CoreException(ErrorType.BAD_REQUEST);
+            throw new CoreException(ErrorType.BAD_REQUEST, "포인트가 부족합니다.");
         }
         this.balance -= amount;
     }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/PointEntity.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/PointEntity.java
@@ -19,10 +19,7 @@ public class PointEntity extends BaseEntity {
 
     private Long balance;
 
-    @Version
-    private Long version;
-
-    @Column(name = "user_id", nullable = false)
+    @Column(name = "user_id", nullable = false, unique = true)
     private Long userId;
 
     public PointEntity(long userId, long balance) {

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/PointRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/PointRepository.java
@@ -8,4 +8,6 @@ public interface PointRepository {
     Optional<PointEntity> findById(Long id);
 
     void save(PointEntity point);
+
+    Optional<PointEntity> findWithLockByUserId(long userId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/PointService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/PointService.java
@@ -19,8 +19,9 @@ public class PointService {
         return pointRepository.findByUserId(userId);
     }
 
+    @Transactional
     public PointEntity chargePoint(long userId, int amount) {
-        PointEntity pointEntity = pointRepository.findByUserId(userId)
+        PointEntity pointEntity = pointRepository.findWithLockByUserId(userId)
                 .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "[id = " + userId + "] 의 포인트를 찾을 수 없습니다."));
 
         pointEntity.charge(amount);
@@ -28,7 +29,7 @@ public class PointService {
     }
 
     public void usePoints(long userId, Long amount) {
-        PointEntity point = pointRepository.findByUserId(userId)
+        PointEntity point = pointRepository.findWithLockByUserId(userId)
                 .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "포인트 정보를 찾을 수 없습니다."));
 
         if (point.getBalance() < amount) {

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductEntity.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductEntity.java
@@ -21,7 +21,7 @@ public class ProductEntity extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private ProductStatus status;
 
-    public ProductEntity(String name, Long price, Long stock, Long brandId){
+    private ProductEntity(String name, Long price, Long stock, Long brandId){
         if(name == null || name.isBlank()){
             throw new CoreException(ErrorType.BAD_REQUEST);
         }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductRepository.java
@@ -6,4 +6,6 @@ public interface ProductRepository {
     ProductEntity save(ProductEntity productEntity);
 
     Optional<ProductEntity> findById(long productId);
+
+    Optional<ProductEntity> findWithLockById(Long id);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
@@ -41,7 +41,7 @@ public class ProductService {
     }
 
     public void decreaseStock(Long productId, Long quantity) {
-        ProductEntity product = productRepository.findById(productId)
+        ProductEntity product = productRepository.findWithLockById(productId)
                 .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "상품을 찾을 수 없습니다."));
 
         product.decreaseStock(quantity);

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
@@ -1,14 +1,20 @@
 package com.loopers.domain.product;
 
+import com.loopers.application.product.ProductQueryRepository;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @Service
 public class ProductService {
     private final ProductRepository productRepository;
+    private final ProductQueryRepository productQueryRepository;
 
     public ProductInfo create(ProductCommand.Create productCommand) {
         ProductEntity productEntity = ProductEntity.of(
@@ -24,6 +30,14 @@ public class ProductService {
         ProductEntity productEntity = productRepository.findById(productId)
                 .orElseThrow(()-> new CoreException(ErrorType.NOT_FOUND));
         return ProductInfo.from(productEntity);
+    }
+
+    public List<ProductInfo> getProducts(ProductSortType sort) {
+        Pageable pageable = PageRequest.of(0, 100);
+        List<ProductEntity> products = productQueryRepository.findBySortType(sort, pageable);
+        return products.stream()
+                .map(ProductInfo::from)
+                .toList();
     }
 
     public void decreaseStock(Long productId, Long quantity) {

--- a/apps/commerce-api/src/main/java/com/loopers/domain/userCoupon/UserCouponCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/userCoupon/UserCouponCommand.java
@@ -1,0 +1,15 @@
+package com.loopers.domain.userCoupon;
+
+public class UserCouponCommand {
+
+    public record Use(Long userId, Long couponId) {}
+
+    public record Create(Long userId, Long couponId) {}
+
+    public record Apply(
+            Long userId,
+            Long couponId,
+            long originalPrice
+    ) {}
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/userCoupon/UserCouponEntity.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/userCoupon/UserCouponEntity.java
@@ -1,0 +1,46 @@
+package com.loopers.domain.userCoupon;
+
+import com.loopers.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "user_coupons")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserCouponEntity extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long userId;
+
+    private Long couponId;
+
+    @Enumerated(EnumType.STRING)
+    private UserCouponStatus status;
+
+    private UserCouponEntity(Long userId, Long couponId) {
+        this.userId = userId;
+        this.couponId = couponId;
+        this.status = UserCouponStatus.ISSUED;
+    }
+
+    public static UserCouponEntity of(Long userId, Long couponId){
+        return new UserCouponEntity(userId, couponId);
+    }
+
+    public void use() {
+        if (this.status != UserCouponStatus.ISSUED) {
+            throw new IllegalStateException("사용할 수 없는 쿠폰 상태입니다.");
+        }
+        this.status = UserCouponStatus.USED;
+    }
+
+    public boolean isUsed() {
+        return this.status == UserCouponStatus.USED;
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/userCoupon/UserCouponInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/userCoupon/UserCouponInfo.java
@@ -1,0 +1,17 @@
+package com.loopers.domain.userCoupon;
+
+public record UserCouponInfo (
+
+        Long userId,
+        Long couponId,
+        UserCouponStatus status
+){
+    public static UserCouponInfo from(UserCouponEntity entity){
+        return new UserCouponInfo(
+                entity.getUserId(),
+                entity.getCouponId(),
+                entity.getStatus()
+        );
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/userCoupon/UserCouponRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/userCoupon/UserCouponRepository.java
@@ -7,4 +7,5 @@ public interface UserCouponRepository {
     Optional<UserCouponEntity> findByUserIdAndCouponId(Long userId, Long couponId);
     UserCouponEntity save(UserCouponEntity userCoupon);
     UserCouponEntity findById(long id);
+    Optional<UserCouponEntity> findWithLockByUserIdAndCouponId(Long userId, Long couponId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/userCoupon/UserCouponRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/userCoupon/UserCouponRepository.java
@@ -1,0 +1,10 @@
+package com.loopers.domain.userCoupon;
+
+
+import java.util.Optional;
+
+public interface UserCouponRepository {
+    Optional<UserCouponEntity> findByUserIdAndCouponId(Long userId, Long couponId);
+    UserCouponEntity save(UserCouponEntity userCoupon);
+    UserCouponEntity findById(long id);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/userCoupon/UserCouponService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/userCoupon/UserCouponService.java
@@ -10,11 +10,10 @@ import static com.loopers.support.error.ErrorType.NOT_FOUND;
 
 @RequiredArgsConstructor
 @Service
-@Transactional
 public class UserCouponService {
     private final UserCouponRepository userCouponRepository;
 
-
+    @Transactional
     public void useCoupon(UserCouponCommand.Use command) {
         UserCouponEntity userCoupon = userCouponRepository
                 .findWithLockByUserIdAndCouponId(command.userId(), command.couponId()) // 비관적 락

--- a/apps/commerce-api/src/main/java/com/loopers/domain/userCoupon/UserCouponService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/userCoupon/UserCouponService.java
@@ -1,0 +1,28 @@
+package com.loopers.domain.userCoupon;
+
+import com.loopers.support.error.CoreException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import static com.loopers.support.error.ErrorType.BAD_REQUEST;
+import static com.loopers.support.error.ErrorType.NOT_FOUND;
+
+@RequiredArgsConstructor
+@Service
+public class UserCouponService {
+    private final UserCouponRepository userCouponRepository;
+
+    public void validateOwnedAndUnused(UserCouponCommand.Use command) {
+        UserCouponEntity userCoupon = userCouponRepository.findByUserIdAndCouponId(command.userId(), command.couponId())
+                .orElseThrow(() -> new CoreException(NOT_FOUND, "소유하지 않은 쿠폰입니다."));
+        if (userCoupon.isUsed()) throw new CoreException(BAD_REQUEST, "이미 사용된 쿠폰입니다.");
+    }
+
+    public void useCoupon(UserCouponCommand.Use command) {
+        UserCouponEntity userCoupon = userCouponRepository.findByUserIdAndCouponId(command.userId(), command.couponId())
+                .orElseThrow(() -> new CoreException(NOT_FOUND, "소유하지 않은 쿠폰입니다."));
+
+        userCoupon.use();
+        userCouponRepository.save(userCoupon);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/userCoupon/UserCouponService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/userCoupon/UserCouponService.java
@@ -1,6 +1,7 @@
 package com.loopers.domain.userCoupon;
 
 import com.loopers.support.error.CoreException;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -9,20 +10,20 @@ import static com.loopers.support.error.ErrorType.NOT_FOUND;
 
 @RequiredArgsConstructor
 @Service
+@Transactional
 public class UserCouponService {
     private final UserCouponRepository userCouponRepository;
 
-    public void validateOwnedAndUnused(UserCouponCommand.Use command) {
-        UserCouponEntity userCoupon = userCouponRepository.findByUserIdAndCouponId(command.userId(), command.couponId())
-                .orElseThrow(() -> new CoreException(NOT_FOUND, "소유하지 않은 쿠폰입니다."));
-        if (userCoupon.isUsed()) throw new CoreException(BAD_REQUEST, "이미 사용된 쿠폰입니다.");
-    }
 
     public void useCoupon(UserCouponCommand.Use command) {
-        UserCouponEntity userCoupon = userCouponRepository.findByUserIdAndCouponId(command.userId(), command.couponId())
+        UserCouponEntity userCoupon = userCouponRepository
+                .findWithLockByUserIdAndCouponId(command.userId(), command.couponId()) // 비관적 락
                 .orElseThrow(() -> new CoreException(NOT_FOUND, "소유하지 않은 쿠폰입니다."));
 
+        if (userCoupon.isUsed()) {
+            throw new CoreException(BAD_REQUEST, "이미 사용된 쿠폰입니다.");
+        }
+
         userCoupon.use();
-        userCouponRepository.save(userCoupon);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/userCoupon/UserCouponStatus.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/userCoupon/UserCouponStatus.java
@@ -1,0 +1,7 @@
+package com.loopers.domain.userCoupon;
+
+public enum UserCouponStatus {
+    ISSUED,
+    USED,
+    EXPIRED
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/CouponJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/CouponJpaRepository.java
@@ -1,0 +1,7 @@
+package com.loopers.infrastructure.coupon;
+
+import com.loopers.domain.coupon.CouponEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CouponJpaRepository extends JpaRepository<CouponEntity, Long> {
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/CouponJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/CouponJpaRepository.java
@@ -1,7 +1,16 @@
 package com.loopers.infrastructure.coupon;
 
 import com.loopers.domain.coupon.CouponEntity;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface CouponJpaRepository extends JpaRepository<CouponEntity, Long> {
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT c FROM CouponEntity c WHERE c.id = :couponId")
+    Optional<CouponEntity> findWithLockById(@Param("couponId") long couponId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/CouponRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/CouponRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.loopers.infrastructure.coupon;
 
 import com.loopers.domain.coupon.CouponEntity;
 import com.loopers.domain.coupon.CouponRepository;
+import com.loopers.domain.point.PointEntity;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -22,4 +23,9 @@ public class CouponRepositoryImpl implements CouponRepository {
     public CouponEntity save(CouponEntity couponEntity) {
         return couponJpaRepository.save(couponEntity);
     }
-}
+
+    @Override
+    public Optional<CouponEntity> findWithLockById(long couponId) {
+        return couponJpaRepository.findWithLockById(couponId);
+    }}
+

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/CouponRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/CouponRepositoryImpl.java
@@ -1,0 +1,25 @@
+package com.loopers.infrastructure.coupon;
+
+import com.loopers.domain.coupon.CouponEntity;
+import com.loopers.domain.coupon.CouponRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Component
+public class CouponRepositoryImpl implements CouponRepository {
+
+    private final CouponJpaRepository couponJpaRepository;
+
+    @Override
+    public Optional<CouponEntity> findById(Long id) {
+        return couponJpaRepository.findById(id);
+    }
+
+    @Override
+    public CouponEntity save(CouponEntity couponEntity) {
+        return couponJpaRepository.save(couponEntity);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/order/OrderJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/order/OrderJpaRepository.java
@@ -2,9 +2,10 @@ package com.loopers.infrastructure.order;
 
 import com.loopers.domain.order.OrderEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface OrderJpaRepository extends JpaRepository<OrderEntity, Long> {
-    List<OrderEntity> findByUserId(Long userId);
+    List<OrderEntity> findByUserId(@Param("userId") Long userId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/point/PointJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/point/PointJpaRepository.java
@@ -1,13 +1,16 @@
 package com.loopers.infrastructure.point;
 
 import com.loopers.domain.point.PointEntity;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface PointJpaRepository extends JpaRepository<PointEntity, Long> {
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT p FROM PointEntity p WHERE p.userId = :userId")
-    Optional<PointEntity> findByUserId(@Param("userId") long userId);
+    Optional<PointEntity> findWithLockByUserId(@Param("userId") long userId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/point/PointJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/point/PointJpaRepository.java
@@ -12,5 +12,5 @@ import java.util.Optional;
 public interface PointJpaRepository extends JpaRepository<PointEntity, Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT p FROM PointEntity p WHERE p.userId = :userId")
-    Optional<PointEntity> findWithLockByUserId(@Param("userId") long userId);
+    Optional<PointEntity> findWithLockByUserId(@Param("userId") Long userId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/point/PointRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/point/PointRepositoryImpl.java
@@ -2,22 +2,21 @@ package com.loopers.infrastructure.point;
 
 import com.loopers.domain.point.PointEntity;
 import com.loopers.domain.point.PointRepository;
-import com.loopers.support.error.CoreException;
-import com.loopers.support.error.ErrorType;
+import com.loopers.domain.product.ProductEntity;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Component;
 
 import java.util.Optional;
 
 @RequiredArgsConstructor
 @Component
-public class
-PointRepositoryImpl implements PointRepository {
+public class PointRepositoryImpl implements PointRepository {
     private final PointJpaRepository pointJpaRepository;
 
     @Override
     public Optional<PointEntity> findByUserId(long userId){
-        return pointJpaRepository.findByUserId(userId);
+        return pointJpaRepository.findById(userId);
     }
 
     @Override
@@ -28,6 +27,11 @@ PointRepositoryImpl implements PointRepository {
     @Override
     public void save(PointEntity point) {
         pointJpaRepository.save(point);
+    }
+
+    @Override
+    public Optional<PointEntity> findWithLockByUserId(long userId) {
+        return pointJpaRepository.findWithLockByUserId(userId);
     }
 }
 

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductJpaRepository.java
@@ -1,7 +1,17 @@
 package com.loopers.infrastructure.product;
 
 import com.loopers.domain.product.ProductEntity;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface ProductJpaRepository extends JpaRepository<ProductEntity, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT p FROM ProductEntity p WHERE p.id = :id")
+    Optional<ProductEntity> findWithLockById(@Param("id") Long id);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
@@ -22,4 +22,9 @@ public class ProductRepositoryImpl implements ProductRepository {
     public Optional<ProductEntity> findById(long productId) {
         return productJpaRepository.findById(productId);
     }
+
+    @Override
+    public Optional<ProductEntity> findWithLockById(Long id) {
+        return productJpaRepository.findWithLockById(id);
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/userCoupon/UserCouponJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/userCoupon/UserCouponJpaRepository.java
@@ -1,9 +1,18 @@
 package com.loopers.infrastructure.userCoupon;
 
 import com.loopers.domain.userCoupon.UserCouponEntity;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
 import java.util.Optional;
 
 public interface UserCouponJpaRepository extends JpaRepository<UserCouponEntity, Long> {
     Optional<UserCouponEntity> findByUserIdAndCouponId(Long userId, Long couponId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT uc FROM UserCouponEntity uc WHERE uc.userId = :userId AND uc.couponId = :couponId")
+    Optional<UserCouponEntity> findWithLockByUserIdAndCouponId(@Param("userId") long userId, @Param("couponId") long couponId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/userCoupon/UserCouponJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/userCoupon/UserCouponJpaRepository.java
@@ -1,0 +1,9 @@
+package com.loopers.infrastructure.userCoupon;
+
+import com.loopers.domain.userCoupon.UserCouponEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
+
+public interface UserCouponJpaRepository extends JpaRepository<UserCouponEntity, Long> {
+    Optional<UserCouponEntity> findByUserIdAndCouponId(Long userId, Long couponId);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/userCoupon/UserCouponRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/userCoupon/UserCouponRepositoryImpl.java
@@ -26,4 +26,8 @@ public class UserCouponRepositoryImpl implements UserCouponRepository {
     public UserCouponEntity findById(long id) {
         return userCouponJpaRepository.findById(id).orElse(null);
     }
+
+    public Optional<UserCouponEntity> findWithLockByUserIdAndCouponId(Long userId, Long couponId) {
+        return userCouponJpaRepository.findWithLockByUserIdAndCouponId(userId, couponId);
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/userCoupon/UserCouponRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/userCoupon/UserCouponRepositoryImpl.java
@@ -1,0 +1,29 @@
+package com.loopers.infrastructure.userCoupon;
+
+import com.loopers.domain.userCoupon.UserCouponEntity;
+import com.loopers.domain.userCoupon.UserCouponRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Component
+public class UserCouponRepositoryImpl implements UserCouponRepository {
+    private final UserCouponJpaRepository userCouponJpaRepository;
+
+    @Override
+    public Optional<UserCouponEntity> findByUserIdAndCouponId(Long userId, Long couponId) {
+        return userCouponJpaRepository.findByUserIdAndCouponId(userId, couponId);
+    }
+
+    @Override
+    public UserCouponEntity save(UserCouponEntity userCouponEntity) {
+        return userCouponJpaRepository.save(userCouponEntity);
+    }
+
+    @Override
+    public UserCouponEntity findById(long id) {
+        return userCouponJpaRepository.findById(id).orElse(null);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ApiControllerAdvice.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ApiControllerAdvice.java
@@ -8,6 +8,7 @@ import com.loopers.support.error.ErrorType;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingRequestHeaderException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -34,6 +35,12 @@ public class ApiControllerAdvice {
     public ResponseEntity<ApiResponse<?>> handleMissingRequestHeader(MissingRequestHeaderException ex) {
         String message = String.format("필수 헤더 누락: %s", ex.getHeaderName());
         return failureResponse(ErrorType.BAD_REQUEST, message);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<?>> handleValidation(MethodArgumentNotValidException ex) {
+        String errorMessage = ex.getBindingResult().getAllErrors().get(0).getDefaultMessage();
+        return failureResponse(ErrorType.BAD_REQUEST, errorMessage);
     }
 
     @ExceptionHandler

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/brand/BrandRequest.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/brand/BrandRequest.java
@@ -1,0 +1,15 @@
+package com.loopers.interfaces.api.brand;
+
+import com.loopers.domain.brand.BrandCommand;
+import jakarta.validation.constraints.NotBlank;
+
+public class BrandRequest {
+    public record Create(
+        @NotBlank String name,
+        String description
+        ){
+        public BrandCommand.Create toCommand(){
+            return new BrandCommand.Create(name, description);
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/brand/BrandResponse.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/brand/BrandResponse.java
@@ -1,0 +1,9 @@
+package com.loopers.interfaces.api.brand;
+
+import com.loopers.domain.brand.BrandInfo;
+
+public record BrandResponse(Long id, String name, String description) {
+    public static BrandResponse from(BrandInfo info) {
+        return new BrandResponse(info.id(), info.name(), info.description());
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/brand/BrandV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/brand/BrandV1ApiSpec.java
@@ -1,0 +1,20 @@
+package com.loopers.interfaces.api.brand;
+
+import com.loopers.interfaces.api.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "Brand API")
+public interface BrandV1ApiSpec {
+
+    @Operation(summary = "브랜드 생성")
+    ApiResponse<BrandResponse> create(@RequestBody BrandRequest.Create brandRequest);
+
+    @GetMapping("/{brandId}")
+    ApiResponse<BrandResponse> getBrand(
+            @Schema(description = "조회할 브랜드 ID") @PathVariable Long brandId);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/brand/BrandV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/brand/BrandV1Controller.java
@@ -1,0 +1,28 @@
+package com.loopers.interfaces.api.brand;
+
+import com.loopers.domain.brand.BrandInfo;
+import com.loopers.domain.brand.BrandService;
+import com.loopers.interfaces.api.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/api/v1/brands")
+@RestController
+@RequiredArgsConstructor
+public class BrandV1Controller implements BrandV1ApiSpec{
+
+    private final BrandService brandService;
+
+    @Override
+    public ApiResponse<BrandResponse> create(BrandRequest.Create brandRequest) {
+        BrandInfo brandInfo = brandService.create(brandRequest.toCommand());
+        return ApiResponse.success(BrandResponse.from(brandInfo));
+    }
+
+    @Override
+    public ApiResponse<BrandResponse> getBrand(Long brandId) {
+        BrandInfo brandInfo = brandService.getBrand(brandId);
+        return ApiResponse.success(BrandResponse.from(brandInfo));
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/coupon/CouponRequest.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/coupon/CouponRequest.java
@@ -1,0 +1,5 @@
+package com.loopers.interfaces.api.coupon;
+
+public class CouponRequest {
+    public record Apply(Long userId, Long couponId, long price) {}
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/coupon/CouponRequest.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/coupon/CouponRequest.java
@@ -1,12 +1,36 @@
 package com.loopers.interfaces.api.coupon;
 
+import com.loopers.domain.coupon.CouponCommand;
+import com.loopers.domain.coupon.DiscountType;
 import com.loopers.domain.userCoupon.UserCouponCommand;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDateTime;
 
 public class CouponRequest {
     public record Apply(Long userId, Long couponId, long originalPrice) {
 
             public UserCouponCommand.Apply toCommand() {
             return new UserCouponCommand.Apply(userId, couponId, originalPrice);
+        }
+    }
+
+    public record Create(
+            @NotBlank String name,
+            @NotNull DiscountType discountType,
+            Long discountAmount,
+            Double discountRate,
+            @NotBlank String expiredAt
+    ) {
+        public CouponCommand.Create toCommand() {
+            return new CouponCommand.Create(
+                    name,
+                    discountType,
+                    discountAmount,
+                    discountRate,
+                    LocalDateTime.parse(expiredAt)
+            );
         }
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/coupon/CouponRequest.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/coupon/CouponRequest.java
@@ -1,5 +1,12 @@
 package com.loopers.interfaces.api.coupon;
 
+import com.loopers.domain.userCoupon.UserCouponCommand;
+
 public class CouponRequest {
-    public record Apply(Long userId, Long couponId, long price) {}
+    public record Apply(Long userId, Long couponId, long originalPrice) {
+
+            public UserCouponCommand.Apply toCommand() {
+            return new UserCouponCommand.Apply(userId, couponId, originalPrice);
+        }
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/coupon/CouponResponse.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/coupon/CouponResponse.java
@@ -1,0 +1,21 @@
+package com.loopers.interfaces.api.coupon;
+
+import com.loopers.domain.coupon.CouponInfo;
+
+public record CouponResponse(
+        Long couponId,
+        String name,
+        String discountType,
+        String status,
+        String expiredAt
+) {
+    public static CouponResponse from(CouponInfo couponInfo) {
+        return new CouponResponse(
+                couponInfo.couponId(),
+                couponInfo.name(),
+                couponInfo.discountType().name(),
+                couponInfo.status().name(),
+                couponInfo.expiredAt().toString()
+        );
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/coupon/CouponV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/coupon/CouponV1ApiSpec.java
@@ -1,0 +1,15 @@
+package com.loopers.interfaces.api.coupon;
+
+import com.loopers.interfaces.api.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Tag(name = "Coupon API")
+@RequestMapping("/api/v1/coupons")
+public interface CouponV1ApiSpec {
+
+    @PostMapping("/apply")
+    ApiResponse<Long> applyCoupon(@RequestBody CouponRequest.Apply request);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/coupon/CouponV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/coupon/CouponV1ApiSpec.java
@@ -1,14 +1,22 @@
 package com.loopers.interfaces.api.coupon;
 
 import com.loopers.interfaces.api.ApiResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Coupon API")
 @RequestMapping("/api/v1/coupons")
 public interface CouponV1ApiSpec {
+
+    @PostMapping
+    ApiResponse<CouponResponse> create(@RequestBody @Valid CouponRequest.Create request);
+
+    @GetMapping("/{couponId}")
+    ApiResponse<CouponResponse> getCoupon(
+            @Schema(name = "쿠폰ID", description = "조회할 쿠폰의 ID") @PathVariable Long couponId
+    );
 
     @PostMapping("/apply")
     ApiResponse<Long> applyCoupon(@RequestBody CouponRequest.Apply request);

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/coupon/CouponV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/coupon/CouponV1Controller.java
@@ -1,8 +1,12 @@
 package com.loopers.interfaces.api.coupon;
 
 import com.loopers.application.coupon.CouponFacade;
+import com.loopers.domain.coupon.CouponInfo;
+import com.loopers.domain.coupon.CouponService;
 import com.loopers.interfaces.api.ApiResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -11,9 +15,21 @@ import org.springframework.web.bind.annotation.RestController;
 public class CouponV1Controller implements CouponV1ApiSpec{
 
     private final CouponFacade couponFacade;
+    private final CouponService couponService;
+
+    public ApiResponse<CouponResponse> create(@RequestBody @Valid CouponRequest.Create request) {
+        var info = couponService.create(request.toCommand());
+        return ApiResponse.success(CouponResponse.from(info));
+    }
 
     @Override
-    public ApiResponse<Long> applyCoupon(@RequestBody CouponRequest.Apply request) {
+    public ApiResponse<CouponResponse> getCoupon(@PathVariable Long couponId) {
+        CouponInfo couponInfo = CouponInfo.from(couponService.getAvailableCoupon(couponId));
+        return ApiResponse.success(CouponResponse.from(couponInfo));
+    }
+
+    @Override
+    public ApiResponse<Long> applyCoupon(@Valid @RequestBody CouponRequest.Apply request) {
         long discounted = couponFacade.applyCoupon(request.toCommand());
         return ApiResponse.success(discounted);
     }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/coupon/CouponV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/coupon/CouponV1Controller.java
@@ -14,7 +14,7 @@ public class CouponV1Controller implements CouponV1ApiSpec{
 
     @Override
     public ApiResponse<Long> applyCoupon(@RequestBody CouponRequest.Apply request) {
-        long discounted = couponFacade.applyCoupon(request.userId(), request.couponId(), request.price());
+        long discounted = couponFacade.applyCoupon(request.toCommand());
         return ApiResponse.success(discounted);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/coupon/CouponV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/coupon/CouponV1Controller.java
@@ -1,0 +1,20 @@
+package com.loopers.interfaces.api.coupon;
+
+import com.loopers.application.coupon.CouponFacade;
+import com.loopers.interfaces.api.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class CouponV1Controller implements CouponV1ApiSpec{
+
+    private final CouponFacade couponFacade;
+
+    @Override
+    public ApiResponse<Long> applyCoupon(@RequestBody CouponRequest.Apply request) {
+        long discounted = couponFacade.applyCoupon(request.userId(), request.couponId(), request.price());
+        return ApiResponse.success(discounted);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/like/LikeResponse.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/like/LikeResponse.java
@@ -1,0 +1,17 @@
+package com.loopers.interfaces.api.like;
+
+import com.loopers.domain.like.LikeInfo;
+
+public record LikeResponse(
+        Long userId,
+        Long productId,
+        boolean liked
+) {
+    public static LikeResponse from(LikeInfo info) {
+        return new LikeResponse(
+                info.userId(),
+                info.productId(),
+                info.isLike()
+        );
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/like/LikeV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/like/LikeV1ApiSpec.java
@@ -1,0 +1,30 @@
+package com.loopers.interfaces.api.like;
+
+import com.loopers.interfaces.api.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "Like API")
+@RequestMapping("/api/v1/likes")
+public interface LikeV1ApiSpec {
+
+    @GetMapping("/products")
+    ResponseEntity<ApiResponse<List<LikeResponse>>> getLikesByUserId(
+            @RequestHeader("X-USER-ID") Long userId
+    );
+
+    @PostMapping("/products/{productId}")
+    ResponseEntity<ApiResponse<LikeResponse>> like(
+            @RequestHeader("X-USER-ID") Long userId,
+            @PathVariable Long productId
+    );
+
+    @DeleteMapping("/products/{productId}")
+    ResponseEntity<ApiResponse<LikeResponse>> unlike(
+            @RequestHeader("X-USER-ID") Long userId,
+            @PathVariable Long productId
+    );
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/like/LikeV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/like/LikeV1Controller.java
@@ -1,0 +1,39 @@
+package com.loopers.interfaces.api.like;
+
+import com.loopers.domain.like.LikeCommand;
+import com.loopers.domain.like.LikeInfo;
+import com.loopers.domain.like.LikeService;
+import com.loopers.interfaces.api.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController
+public class LikeV1Controller implements LikeV1ApiSpec {
+
+    private final LikeService likeService;
+
+    @Override
+    public ResponseEntity<ApiResponse<List<LikeResponse>>> getLikesByUserId(Long userId) {
+        List<LikeResponse> likes = likeService.getLikesByUserId(userId).stream()
+                .map(LikeResponse::from)
+                .toList();
+
+        return ResponseEntity.ok(ApiResponse.success(likes));
+    }
+
+    @Override
+    public ResponseEntity<ApiResponse<LikeResponse>> like(Long userId, Long productId) {
+        LikeInfo likeInfo = likeService.like(new LikeCommand.Create(userId, productId));
+        return ResponseEntity.ok(ApiResponse.success(LikeResponse.from(likeInfo)));
+    }
+
+    @Override
+    public ResponseEntity<ApiResponse<LikeResponse>> unlike(Long userId, Long productId) {
+        LikeInfo unlikeInfo = likeService.unlike(new LikeCommand.Create(userId, productId));
+        return ResponseEntity.ok(ApiResponse.success(LikeResponse.from(unlikeInfo)));
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/order/OrderRequest.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/order/OrderRequest.java
@@ -7,14 +7,14 @@ import java.util.List;
 
 public class OrderRequest {
     public record Create(
-            @NotNull List<OrderCommand.OrderItem> orderItems
+            @NotNull List<OrderCommand.OrderItem> orderItems, Long couponId
     ) {
         public OrderCommand.Order toCommand(Long userId) {
             List<OrderCommand.OrderItem> items = orderItems.stream()
                     .map(item -> new OrderCommand.OrderItem(item.productId(), item.quantity(), item.price()))
                     .toList();
 
-            return new OrderCommand.Order(userId, items);
+            return new OrderCommand.Order(userId, items, couponId);
         }
     }
 

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/order/OrderRequest.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/order/OrderRequest.java
@@ -1,0 +1,21 @@
+package com.loopers.interfaces.api.order;
+
+import com.loopers.domain.order.OrderCommand;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+public class OrderRequest {
+    public record Create(
+            @NotNull List<OrderCommand.OrderItem> orderItems
+    ) {
+        public OrderCommand.Order toCommand(Long userId) {
+            List<OrderCommand.OrderItem> items = orderItems.stream()
+                    .map(item -> new OrderCommand.OrderItem(item.productId(), item.quantity(), item.price()))
+                    .toList();
+
+            return new OrderCommand.Order(userId, items);
+        }
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/order/OrderResponse.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/order/OrderResponse.java
@@ -1,0 +1,42 @@
+package com.loopers.interfaces.api.order;
+
+import com.loopers.domain.order.OrderInfo;
+
+import java.util.List;
+
+public class OrderResponse {
+
+    public record Detail(
+            Long orderId,
+            Long userId,
+            Long totalPrice,
+            List<OrderInfo.OrderItemInfo> orderItems
+    ) {
+        public static Detail from(OrderInfo orderInfo) {
+            List<OrderItem> items = orderInfo.orderItems().stream()
+                    .map(OrderItem::from)
+                    .toList();
+
+            return new Detail(
+                    orderInfo.id(),
+                    orderInfo.userId(),
+                    orderInfo.totalPrice(),
+                    orderInfo.orderItems()
+            );
+        }
+    }
+
+    public record OrderItem(
+            Long productId,
+            Long quantity,
+            Long price
+    ) {
+        public static OrderItem from(OrderInfo.OrderItemInfo info) {
+            return new OrderItem(
+                    info.productId(),
+                    info.quantity(),
+                    info.price()
+            );
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/order/OrderV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/order/OrderV1ApiSpec.java
@@ -1,0 +1,29 @@
+package com.loopers.interfaces.api.order;
+
+import com.loopers.interfaces.api.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "Order API")
+@RequestMapping("/api/v1/orders")
+public interface OrderV1ApiSpec {
+
+    @PostMapping
+    @Operation(summary = "주문 생성")
+    ApiResponse<OrderResponse.Detail> createOrder(
+            @RequestHeader("X-USER-ID") Long userId, @RequestBody OrderRequest.Create orderRequest);
+
+    @Operation(summary = "사용자의 주문 목록 조회")
+    @GetMapping
+    ApiResponse<List<OrderResponse.Detail>> getOrders(
+            @RequestHeader("X-USER-ID") Long userId
+    );
+
+    @Operation(summary = "주문 상세 조회")
+    @GetMapping("/{orderId}")
+    ApiResponse<OrderResponse.Detail> getOrder(@PathVariable Long orderId);
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/order/OrderV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/order/OrderV1Controller.java
@@ -1,0 +1,39 @@
+package com.loopers.interfaces.api.order;
+
+import com.loopers.application.order.OrderFacade;
+import com.loopers.domain.order.OrderInfo;
+import com.loopers.domain.order.OrderService;
+import com.loopers.interfaces.api.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class OrderV1Controller implements OrderV1ApiSpec {
+
+    private final OrderService orderService;
+    private final OrderFacade orderFacade;
+
+    @Override
+    public ApiResponse<OrderResponse.Detail> createOrder(Long userId, OrderRequest.Create orderRequest) {
+        OrderInfo orderInfo = orderFacade.createOrder(orderRequest.toCommand(userId));
+        return ApiResponse.success(OrderResponse.Detail.from(orderInfo));
+    }
+
+    @Override
+    public ApiResponse<List<OrderResponse.Detail>> getOrders(Long userId) {
+        List<OrderInfo> orderInfos = orderService.getOrders(userId);
+        List<OrderResponse.Detail> response = orderInfos.stream()
+                .map(OrderResponse.Detail::from)
+                .toList();
+        return ApiResponse.success(response);
+    }
+
+    @Override
+    public ApiResponse<OrderResponse.Detail> getOrder(Long orderId) {
+        OrderInfo orderInfo = orderService.getOrder(orderId);
+        return ApiResponse.success(OrderResponse.Detail.from(orderInfo));
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/order/OrderV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/order/OrderV1Controller.java
@@ -5,6 +5,7 @@ import com.loopers.domain.order.OrderInfo;
 import com.loopers.domain.order.OrderService;
 import com.loopers.interfaces.api.ApiResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -23,7 +24,7 @@ public class OrderV1Controller implements OrderV1ApiSpec {
     }
 
     @Override
-    public ApiResponse<List<OrderResponse.Detail>> getOrders(Long userId) {
+    public ApiResponse<List<OrderResponse.Detail>> getOrders(@RequestHeader("X-USER-ID") Long userId) {
         List<OrderInfo> orderInfos = orderService.getOrders(userId);
         List<OrderResponse.Detail> response = orderInfos.stream()
                 .map(OrderResponse.Detail::from)

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1ApiSpec.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 public interface PointV1ApiSpec {
 
     ApiResponse<PointResponse> getPoint(
-            @Schema(name = "유저 ID", description = "포인트를 조회할 유저의 ID")
+            @Schema(name = "X-USER-ID")
             Long userId
     );
 

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1ApiSpec.java
@@ -6,8 +6,10 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 
 @Tag(name ="Point V1 API")
+@RequestMapping("/api/v1/points")
 public interface PointV1ApiSpec {
 
     ApiResponse<PointResponse> getPoint(

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1Controller.java
@@ -34,7 +34,6 @@ public class PointV1Controller implements PointV1ApiSpec{
         return ApiResponse.success(response);
     }
 
-    @PostMapping("/charge")
     @Override
     public ApiResponse<PointResponse> charge(
             @RequestHeader(value = "X-USER-ID") Long userId,

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductRequest.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductRequest.java
@@ -1,0 +1,19 @@
+package com.loopers.interfaces.api.product;
+
+import com.loopers.domain.product.ProductCommand;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public class ProductRequest {
+
+    public record Create(
+            @NotBlank String name,
+            @NotNull Long price,
+            @NotNull Long stock,
+            @NotNull Long brandId
+    ) {
+        public ProductCommand.Create toCommand() {
+            return new ProductCommand.Create(name, price, stock, brandId);
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductResponse.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductResponse.java
@@ -1,0 +1,21 @@
+package com.loopers.interfaces.api.product;
+
+import com.loopers.domain.product.ProductInfo;
+
+public record ProductResponse(
+        Long id,
+        String name,
+        Long price,
+        Long stock,
+        Long brandId
+) {
+    public static ProductResponse from(ProductInfo info) {
+        return new ProductResponse(
+                info.id(),
+                info.name(),
+                info.price(),
+                info.stock(),
+                info.brandId()
+        );
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1ApiSpec.java
@@ -1,0 +1,34 @@
+package com.loopers.interfaces.api.product;
+
+import com.loopers.domain.product.ProductSortType;
+import com.loopers.interfaces.api.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "Product API")
+@RequestMapping("/api/v1/products")
+public interface ProductV1ApiSpec {
+
+    @Operation(summary = "상품 생성")
+    ApiResponse<ProductResponse> create(
+            @RequestBody ProductRequest.Create productRequest
+    );
+
+    @GetMapping("/{productId}")
+    ApiResponse<ProductResponse> getProduct(
+            @Schema(name = "상품ID", description = "조회할 상품의 ID") @PathVariable Long productId
+    );
+
+    @Operation(summary = "상품 목록 조회")
+    @GetMapping
+    ApiResponse<List<ProductResponse>> getProducts(
+            @Schema(description = "정렬 기준", example = "LATEST | PRICE_ASC | LIKES_DESC")
+            @RequestParam(name = "sort", required = false, defaultValue = "LATEST")
+            ProductSortType sort
+    );
+}
+

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Controller.java
@@ -1,0 +1,41 @@
+package com.loopers.interfaces.api.product;
+
+import com.loopers.domain.product.ProductInfo;
+import com.loopers.domain.product.ProductService;
+import com.loopers.domain.product.ProductSortType;
+import com.loopers.interfaces.api.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RequestMapping("/api/v1/products")
+@RestController
+@RequiredArgsConstructor
+public class ProductV1Controller implements ProductV1ApiSpec{
+
+    private final ProductService productService;
+
+    @Override
+    public ApiResponse<ProductResponse> create(ProductRequest.Create productRequest) {
+        ProductInfo productInfo = productService.create(productRequest.toCommand());
+        return ApiResponse.success(ProductResponse.from(productInfo));
+    }
+
+    @Override
+    public ApiResponse<ProductResponse> getProduct(Long productId) {
+        ProductInfo productInfo = productService.getProduct(productId);
+        return ApiResponse.success(ProductResponse.from(productInfo));
+    }
+
+    @Override
+    public ApiResponse<List<ProductResponse>> getProducts(ProductSortType sort) {
+        List<ProductInfo> products = productService.getProducts(sort);
+        List<ProductResponse> responses = products.stream()
+                .map(ProductResponse::from)
+                .toList();
+
+        return ApiResponse.success(responses);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Controller.java
@@ -5,12 +5,10 @@ import com.loopers.domain.product.ProductService;
 import com.loopers.domain.product.ProductSortType;
 import com.loopers.interfaces.api.ApiResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
-@RequestMapping("/api/v1/products")
 @RestController
 @RequiredArgsConstructor
 public class ProductV1Controller implements ProductV1ApiSpec{

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserRequest.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserRequest.java
@@ -4,21 +4,21 @@ import com.loopers.domain.user.Gender;
 import com.loopers.domain.user.UserCommand;
 import com.loopers.domain.user.vo.Birth;
 import com.loopers.domain.user.vo.Email;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
 
 public record UserRequest(
-        @NotNull
+        @NotBlank
         String userId,
-        @NotNull
+        @NotBlank
         String name,
-        @NotNull
+        @NotBlank
         String gender,
-        @NotNull
+        @NotBlank
         String birth,
-        @NotNull
+        @NotBlank
         String email
 ) {
     public UserCommand.SignUp toCommand() {
-        return new UserCommand.SignUp(userId, name, Gender.valueOf(gender), Birth.of(birth), Email.of(email));
+        return new UserCommand.SignUp(userId, name, Gender.from(gender), Birth.of(birth), Email.of(email));
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserResponse.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserResponse.java
@@ -11,10 +11,15 @@ public record UserResponse(
 ) {
 
     public static UserResponse from(UserInfo userInfo) {
+        String gender = switch (userInfo.gender()){
+            case FEMALE -> "F";
+            case MALE -> "M";
+            default -> null;
+        };
         return new UserResponse(
                 userInfo.userId(),
                 userInfo.name(),
-                userInfo.gender().name(),
+                gender,
                 userInfo.birth().getValue(),
                 userInfo.email().getValue()
         );

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1ApiSpec.java
@@ -5,14 +5,19 @@ import com.loopers.interfaces.api.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 
 @Tag(name ="User V1 API")
+@RequestMapping("/api/v1/users")
 public interface UserV1ApiSpec {
 
     @Operation(summary = "회원 가입")
     ApiResponse<UserResponse> signUp(
             UserRequest signUpRequest
     );
+
+    @GetMapping("/{userId}")
     ApiResponse<UserResponse> getUserInfo(
             @Schema(name = "유저Id", description = "조회할 유저의 ID")
             String userId

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Controller.java
@@ -5,6 +5,7 @@ import com.loopers.application.user.UserFacade;
 import com.loopers.domain.user.UserInfo;
 import com.loopers.interfaces.api.ApiResponse;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -16,7 +17,7 @@ public class UserV1Controller implements UserV1ApiSpec {
 
     @PostMapping
     @Override
-    public ApiResponse<UserResponse> signUp(@RequestBody UserRequest signUpRequest
+    public ApiResponse<UserResponse> signUp(@RequestBody @Valid UserRequest signUpRequest
     ){
         final  UserResponse response = UserResponse.from(userFacade.signUp(signUpRequest.toCommand()));
         return ApiResponse.success(response);

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Controller.java
@@ -10,7 +10,6 @@ import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/api/v1/users")
 public class UserV1Controller implements UserV1ApiSpec {
 
     private final UserFacade userFacade;

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Controller.java
@@ -23,7 +23,6 @@ public class UserV1Controller implements UserV1ApiSpec {
         return ApiResponse.success(response);
     }
 
-    @GetMapping("/{userId}")
     @Override
     public ApiResponse<UserResponse> getUserInfo(
             @PathVariable(value = "userId") String userId

--- a/apps/commerce-api/src/test/java/com/loopers/application/coupon/CouponFacadeIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/coupon/CouponFacadeIntegrationTest.java
@@ -1,0 +1,105 @@
+package com.loopers.application.coupon;
+
+import com.loopers.application.order.OrderFacade;
+import com.loopers.domain.coupon.CouponEntity;
+import com.loopers.domain.coupon.CouponRepository;
+import com.loopers.domain.coupon.DiscountType;
+import com.loopers.domain.order.OrderCommand;
+import com.loopers.domain.point.PointEntity;
+import com.loopers.domain.point.PointRepository;
+import com.loopers.domain.userCoupon.UserCouponEntity;
+import com.loopers.domain.userCoupon.UserCouponRepository;
+import com.loopers.utils.DatabaseCleanUp;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("CouponFacade 통합 테스트")
+@SpringBootTest
+@Transactional
+public class CouponFacadeIntegrationTest {
+
+    @Autowired
+    private UserCouponRepository userCouponRepository;
+
+    @Autowired
+    private CouponRepository couponRepository;
+
+    @Autowired
+    private PointRepository pointRepository;
+
+    @Autowired
+    private OrderFacade orderFacade;
+
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @Test
+    @DisplayName("동일한 쿠폰을 여러 스레드에서 동시에 사용할 경우, 한 번만 성공한다.")
+    void concurrentCouponUse_onlyOneSuccess() throws InterruptedException {
+        long userId = 1L;
+
+        // 쿠폰 생성 및 발급
+        CouponEntity coupon = couponRepository.save(CouponEntity.of(
+                "테스트쿠폰",
+                DiscountType.FIXED_AMOUNT,
+                1000L,             // 할인 금액
+                null,              // 정액 할인일 경우 rate는 null
+                LocalDateTime.now().plusMinutes(10)
+        ));
+        coupon.applyDiscount(1_000L);
+
+        userCouponRepository.save(UserCouponEntity.of(userId, coupon.getId()));
+
+        pointRepository.save(new PointEntity(userId, 10_000L));
+
+        OrderCommand.Order orderCommand = new OrderCommand.Order(
+                userId,
+                List.of(new OrderCommand.OrderItem(1L, 1L, 5_000L)),
+                coupon.getId()
+        );
+
+        int threadCount = 10;
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger failureCount = new AtomicInteger(0);
+
+        // when
+        for (int i = 0; i < threadCount; i++) {
+            executor.submit(() -> {
+                try {
+                    orderFacade.createOrder(orderCommand);
+                    successCount.incrementAndGet();
+                } catch (Exception e) {
+                    failureCount.incrementAndGet();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        // then
+        assertThat(successCount.get()).isEqualTo(1);
+        assertThat(failureCount.get()).isEqualTo(threadCount - 1);
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/application/like/LikeFacadeIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/like/LikeFacadeIntegrationTest.java
@@ -1,40 +1,50 @@
 package com.loopers.application.like;
 
+import com.loopers.domain.brand.BrandEntity;
+import com.loopers.domain.brand.BrandRepository;
 import com.loopers.domain.like.LikeCommand;
 import com.loopers.domain.like.LikeService;
-import com.loopers.domain.product.ProductInfo;
+import com.loopers.domain.product.*;
 import com.loopers.domain.user.UserInfo;
 import com.loopers.domain.brand.BrandCommand;
 import com.loopers.domain.brand.BrandService;
-import com.loopers.domain.product.ProductCommand;
-import com.loopers.domain.product.ProductService;
 import com.loopers.domain.user.Gender;
 import com.loopers.domain.user.UserCommand;
 import com.loopers.domain.user.UserService;
 import com.loopers.domain.user.vo.Birth;
 import com.loopers.domain.user.vo.Email;
+import com.loopers.utils.DatabaseCleanUp;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.concurrent.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DisplayName("LikeFacade 통합 테스트")
 @SpringBootTest
-@Transactional
 public class LikeFacadeIntegrationTest {
 
-    @Autowired
-    private LikeFacade likeFacade;
+    @Autowired private LikeFacade likeFacade;
     @Autowired private UserService userService;
     @Autowired private BrandService brandService;
     @Autowired private ProductService productService;
     @Autowired private LikeService likeService;
+    @Autowired private BrandRepository brandRepository;
+    @Autowired private ProductRepository productRepository;
+
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
 
     private UserInfo userInfo;
     private ProductInfo productInfo;
@@ -72,4 +82,69 @@ public class LikeFacadeIntegrationTest {
         assertThat(likedProduct.price()).isEqualTo(productInfo.price());
         assertThat(likedProduct.stock()).isEqualTo(productInfo.stock());
     }
+
+    @Test
+    @DisplayName("같은 유저가 동일 상품에 대해 동시에 여러 번 '좋아요' 요청해도 최종 좋아요 수는 1")
+    void concurrent_like_sameUser_isIdempotent() throws Exception {
+        final long userId = 1L;
+        final int threads = 50;
+        BrandEntity brand = brandRepository.save(BrandEntity.of("Brand", "desc"));
+        ProductEntity product = productRepository.save(ProductEntity.of("상품", 10_000L, 100L, brand.getId()));
+
+        ExecutorService es = Executors.newFixedThreadPool(threads);
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(threads);
+
+        for (int i = 0; i < threads; i++) {
+            es.submit(() -> {
+                try {
+                    start.await();
+                    likeService.like(new com.loopers.domain.like.LikeCommand.Create(userId, product.getId()));
+                } catch (Exception ignored) {
+                } finally {
+                    done.countDown();
+                }
+            });
+        }
+
+        start.countDown();
+        es.shutdown();
+        assertTrue(es.awaitTermination(10, TimeUnit.SECONDS));
+        long count = likeService.countByProductId(product.getId());
+        assertThat(count).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("여러 유저가 동시에 같은 상품에 좋아요를 요청해도 중복 없이 유저 수 만큼만 증가")
+    void concurrent_like_manyUsers_distinctOnly() throws Exception {
+        final int users = 100; // 100명의 서로 다른 유저
+
+        BrandEntity brand = brandRepository.save(BrandEntity.of("Brand", "desc"));
+        ProductEntity product = productRepository.save(ProductEntity.of("상품", 10_000L, 100L, brand.getId()));
+
+
+        ExecutorService es = Executors.newFixedThreadPool(32);
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(users);
+
+        for (int i = 0; i < users; i++) {
+            final long userId = i + 1L;
+            es.submit(() -> {
+                try {
+                    start.await();
+                    likeService.like(new com.loopers.domain.like.LikeCommand.Create(userId, product.getId()));
+                } catch (Exception ignored) {
+                } finally {
+                    done.countDown();
+                }
+            });
+        }
+
+        start.countDown();
+        es.shutdown();
+        assertTrue(es.awaitTermination(10, TimeUnit.SECONDS));
+        long count = likeService.countByProductId(product.getId());
+        assertThat(count).isEqualTo(users);
+    }
+
 }

--- a/apps/commerce-api/src/test/java/com/loopers/application/product/ProductFacadeIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/product/ProductFacadeIntegrationTest.java
@@ -48,7 +48,7 @@ class ProductFacadeIntegrationTest {
         // arrange
         BrandEntity brand = brandRepository.save(BrandEntity.of("Apple", "애플 브랜드"));
         ProductEntity product = productRepository.save(
-                new ProductEntity("아이폰", 1200000L, 15L, brand.getId())
+                ProductEntity.of("아이폰", 1200000L, 15L, brand.getId())
         );
         likeRepository.save(LikeEntity.of(1L, product.getId()));
         likeRepository.save(LikeEntity.of(2L, product.getId()));
@@ -67,8 +67,8 @@ class ProductFacadeIntegrationTest {
     void getProductsSorted_latest() {
         // arrange
         BrandEntity brand = brandRepository.save(BrandEntity.of("Apple", "애플 브랜드"));
-        productRepository.save(new ProductEntity("구형 모델", 500000L, 3L, brand.getId()));
-        productRepository.save(new ProductEntity("신형 모델", 1500000L, 2L, brand.getId()));
+        productRepository.save(ProductEntity.of("구형 모델", 500000L, 3L, brand.getId()));
+        productRepository.save(ProductEntity.of("신형 모델", 1500000L, 2L, brand.getId()));
         Pageable pageable = PageRequest.of(0, 10);
 
         // act
@@ -85,8 +85,8 @@ class ProductFacadeIntegrationTest {
     void getProductsSorted_priceAsc() {
         // arrange
         BrandEntity brand = brandRepository.save(BrandEntity.of("Apple", "애플 브랜드"));
-        productRepository.save(new ProductEntity("비싼 상품", 200000L, 5L, brand.getId()));
-        productRepository.save(new ProductEntity("저렴한 상품", 100000L, 3L, brand.getId()));
+        productRepository.save(ProductEntity.of("비싼 상품", 200000L, 5L, brand.getId()));
+        productRepository.save(ProductEntity.of("저렴한 상품", 100000L, 3L, brand.getId()));
         Pageable pageable = PageRequest.of(0, 10);
 
         // act
@@ -103,8 +103,8 @@ class ProductFacadeIntegrationTest {
     void getProductsSorted_likesDesc() {
         // arrange
         BrandEntity brand = brandRepository.save(BrandEntity.of("Apple", "애플 브랜드"));
-        ProductEntity productA = productRepository.save(new ProductEntity("상품A", 10000L, 1L, brand.getId()));
-        ProductEntity productB = productRepository.save(new ProductEntity("상품B", 10000L, 1L, brand.getId()));
+        ProductEntity productA = productRepository.save(ProductEntity.of("상품A", 10000L, 1L, brand.getId()));
+        ProductEntity productB = productRepository.save(ProductEntity.of("상품B", 10000L, 1L, brand.getId()));
 
         likeRepository.save(LikeEntity.of(1L, productA.getId()));
         likeRepository.save(LikeEntity.of(2L, productA.getId()));

--- a/apps/commerce-api/src/test/java/com/loopers/domain/coupon/CouponServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/coupon/CouponServiceIntegrationTest.java
@@ -1,0 +1,146 @@
+package com.loopers.domain.coupon;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CouponServiceIntegrationTest {
+
+    @Mock
+    CouponRepository couponRepository;
+
+    @InjectMocks
+    CouponService couponService;
+
+    private static LocalDateTime future() { return LocalDateTime.now().plusDays(1); }
+    private static LocalDateTime past()   { return LocalDateTime.now().minusDays(1); }
+
+    private static CouponEntity fixedAmount(long amount) {
+        return CouponEntity.of("A쿠폰", DiscountType.FIXED_AMOUNT, amount, null, future());
+    }
+    private static CouponEntity fixedRate(double rate) {
+        return CouponEntity.of("B쿠폰", DiscountType.FIXED_RATE, null, rate, future());
+    }
+
+    @Nested
+    @DisplayName("create")
+    class Create {
+
+        @Test
+        @DisplayName("유효한 커맨드면 저장하고 CouponInfo를 반환한다")
+        void returnCouponInfo_whenCouponCreated() {
+            // arrange
+            var coupon = new CouponCommand.Create("신규쿠폰", DiscountType.FIXED_AMOUNT, 2000L, null, future());
+
+            when(couponRepository.save(any(CouponEntity.class)))
+                    .then(inv -> inv.getArgument(0, CouponEntity.class));
+
+            // act
+            var couponInfo = couponService.create(coupon);
+
+            // assert
+            assertThat(couponInfo).isNotNull();
+
+            ArgumentCaptor<CouponEntity> captor = ArgumentCaptor.forClass(CouponEntity.class);
+            verify(couponRepository, times(1)).save(captor.capture());
+            var saved = captor.getValue();
+            assertThat(saved.getName()).isEqualTo("신규쿠폰");
+            assertThat(saved.getDisCountType()).isEqualTo(DiscountType.FIXED_AMOUNT);
+            assertThat(saved.getDiscountAmount()).isEqualTo(2000L);
+            assertThat(saved.getCouponStatus()).isEqualTo(CouponStatus.AVAILABLE);
+        }
+    }
+
+    @Nested
+    @DisplayName("쿠폰 조회")
+    class GetAvailableCoupon {
+
+        @Test
+        @DisplayName("존재하고 사용 가능하면 엔티티를 반환한다")
+        void returnCouponEntity_whenCouponIsAvailable() {
+            // arrange
+            var coupon = fixedAmount(1000L);
+            when(couponRepository.findWithLockById(1L)).thenReturn(Optional.of(coupon));
+
+            // act
+            var result = couponService.getAvailableCoupon(1L);
+
+            // assert
+            assertThat(result).isSameAs(coupon);
+            verify(couponRepository).findWithLockById(1L);
+        }
+
+        @Test
+        @DisplayName("존재하지 않으면 NOT_FOUND 예외를 던진다")
+        void throwException_whenCouponNotFound() {
+            // arrange
+            when(couponRepository.findWithLockById(99L)).thenReturn(Optional.empty());
+
+            // act & assert
+            assertThatThrownBy(() -> couponService.getAvailableCoupon(99L))
+                    .isInstanceOf(CoreException.class)
+                    .hasMessageContaining("존재하지 않는 쿠폰")
+                    .extracting("errorType")
+                    .isEqualTo(ErrorType.NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("만료되었거나 사용 불가면 BAD_REQUEST 예외를 던진다")
+        void throwException_whenCouponUnavailable() {
+            // arrange: 만료된 쿠폰
+            var expired = CouponEntity.of("만료", DiscountType.FIXED_AMOUNT, 1000L, null, past());
+            when(couponRepository.findWithLockById(5L)).thenReturn(Optional.of(expired));
+
+            // act & assert
+            assertThatThrownBy(() -> couponService.getAvailableCoupon(5L))
+                    .isInstanceOf(CoreException.class)
+                    .hasMessageContaining("사용이 불가한 쿠폰")
+                    .extracting("errorType")
+                    .isEqualTo(ErrorType.BAD_REQUEST);
+        }
+    }
+
+    @Nested
+    @DisplayName("할인 적용")
+    class ApplyDiscount {
+
+        @Test
+        @DisplayName("정액 쿠폰은 원가에서 할인액을 차감한다(하한 0)")
+        void returnDiscountedPrice_whenFixedAmountCoupon() {
+            var coupon = fixedAmount(2_000L);
+
+            long discounted1 = couponService.applyDiscount(coupon, 10_000L);
+            long discounted2 = couponService.applyDiscount(coupon, 1_000L);
+
+            assertThat(discounted1).isEqualTo(8_000L);
+            assertThat(discounted1).isBetween(0L, 10_000L);
+            assertThat(discounted2).isZero();
+        }
+
+        @Test
+        @DisplayName("정률 쿠폰은 소수점 이하는 버림 처리된다")
+        void returnDiscountedPrice_whenFixedRateCoupon() {
+            var coupon = fixedRate(0.10); // 10%
+            long discountedA = couponService.applyDiscount(coupon, 10_000L); // 9000
+            long discountedB = couponService.applyDiscount(coupon, 10_005L); // 9004.5 -> 9004
+
+            assertThat(discountedA).isEqualTo((long) (10_000L * (1 - 0.10)));
+            assertThat(discountedB).isEqualTo((long) (10_005L * (1 - 0.10)));
+            assertThat(discountedA).isBetween(0L, 10_000L);
+            assertThat(discountedB).isBetween(0L, 10_005L);
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/coupon/CouponTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/coupon/CouponTest.java
@@ -1,0 +1,99 @@
+package com.loopers.domain.coupon;
+
+import com.loopers.support.error.CoreException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.*;
+
+class CouponTest {
+
+    private static LocalDateTime future() { return LocalDateTime.now().plusDays(1); }
+    private static LocalDateTime past()   { return LocalDateTime.now().minusDays(1); }
+
+    @Test
+    @DisplayName("정액 쿠폰 생성 성공")
+    void returnFixedAmountCoupon_whenCreated() {
+        var coupon = CouponEntity.of("신규쿠폰", DiscountType.FIXED_AMOUNT, 2_000L, null, future());
+
+        assertThat(coupon.getName()).isEqualTo("신규쿠폰");
+        assertThat(coupon.getDisCountType()).isEqualTo(DiscountType.FIXED_AMOUNT);
+        assertThat(coupon.getDiscountAmount()).isEqualTo(2_000L);
+        assertThat(coupon.getCouponStatus()).isEqualTo(CouponStatus.AVAILABLE);
+        assertThat(coupon.getExpiredAt()).isAfter(LocalDateTime.now());
+        assertThat(coupon.isAvailable()).isTrue();
+    }
+
+    @Test
+    @DisplayName("쿠폰 이름이 비면 생성 실패")
+    void throwException_whenNameBlank() {
+        assertThatThrownBy(() -> CouponEntity.of("  ", DiscountType.FIXED_AMOUNT, 1000L, null, future()))
+                .isInstanceOf(CoreException.class)
+                .hasMessageContaining("쿠폰 이름은 필수입니다.");
+    }
+
+    @Test
+    @DisplayName("할인정책이 null이면 생성 실패")
+    void throwException_whenDiscountTypeNull() {
+        assertThatThrownBy(() -> CouponEntity.of("A쿠폰", null, 1000L, null, future()))
+                .isInstanceOf(CoreException.class)
+                .hasMessageContaining("할인 정책은 필수입니다.");
+    }
+
+    @Test
+    @DisplayName("사용 가능: 상태 AVAILABLE 이고 만료일이 미래")
+    void returnTrue_whenAvailableAndFuture() {
+        var coupon = CouponEntity.of("A쿠폰", DiscountType.FIXED_AMOUNT, 1000L, null, future());
+
+        assertThat(coupon.getCouponStatus()).isEqualTo(CouponStatus.AVAILABLE);
+        assertThat(coupon.getExpiredAt()).isAfter(LocalDateTime.now());
+    }
+
+    @Test
+    @DisplayName("사용 불가: 만료됨")
+    void returnFalse_whenExpired() {
+        var coupon = CouponEntity.of("A쿠폰", DiscountType.FIXED_AMOUNT, 1000L, null, past());
+
+        assertThat(coupon.getExpiredAt()).isBefore(LocalDateTime.now());
+        assertThat(coupon.isAvailable()).isFalse();
+    }
+
+    @Test
+    @DisplayName("정액 할인: 가격보다 큰 할인은 0원으로 설정")
+    void returnZero_whenFixedAmountExceedsPrice() {
+        var coupon = CouponEntity.of("A쿠폰", DiscountType.FIXED_AMOUNT, 2_000L, null, future());
+        assertThat(coupon.applyDiscount(1_000L)).isZero();
+
+        long discountedNormal = coupon.applyDiscount(10_000L);
+        assertThat(discountedNormal)
+                .isEqualTo(8_000L);
+    }
+
+    @Test
+    @DisplayName("정률 할인")
+    void returnDiscountedPrice_whenFixedRate() {
+        var coupon = CouponEntity.of("B쿠폰", DiscountType.FIXED_RATE, null, 0.10, future()); // 10%
+        assertThat(coupon.applyDiscount(10_000L)).isEqualTo((long) (10_000L * (1 - 0.10))); // 9000
+
+        long discountedFraction = coupon.applyDiscount(10_005L); // 9004.5 → 9004
+        assertThat(discountedFraction).isEqualTo((long) (10_005L * (1 - 0.10)));
+    }
+
+    @Test
+    @DisplayName("이미 사용된 쿠폰은 다시 사용할 수 없음")
+    void throwException_whenMarkAsUsedTwice() {
+        var coupon = CouponEntity.of("A쿠폰", DiscountType.FIXED_AMOUNT, 1000L, null, future());
+        // 1회 사용
+        assertThat(coupon.getCouponStatus()).isEqualTo(CouponStatus.AVAILABLE);
+        coupon.markAsUsed();
+        assertThat(coupon.getCouponStatus()).isEqualTo(CouponStatus.USED);
+        assertThat(coupon.isAvailable()).isFalse();
+
+        // 2회 사용 시 예외
+        assertThatThrownBy(coupon::markAsUsed)
+                .isInstanceOf(CoreException.class)
+                .hasMessageContaining("이미 사용된 쿠폰");
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/like/LikeServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/like/LikeServiceIntegrationTest.java
@@ -1,7 +1,7 @@
 package com.loopers.domain.like;
 
-import com.loopers.domain.brand.BrandInfo;
-import com.loopers.domain.product.ProductInfo;
+import com.loopers.domain.brand.*;
+import com.loopers.domain.product.*;
 import com.loopers.domain.user.UserInfo;
 import com.loopers.domain.brand.BrandCommand;
 import com.loopers.domain.brand.BrandService;
@@ -13,17 +13,15 @@ import com.loopers.domain.user.UserService;
 import com.loopers.domain.user.vo.Birth;
 import com.loopers.domain.user.vo.Email;
 import com.loopers.utils.DatabaseCleanUp;
-import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
-@Transactional
 @DisplayName("LikeService 통합 테스트")
 public class LikeServiceIntegrationTest {
 

--- a/apps/commerce-api/src/test/java/com/loopers/domain/order/OrderServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/order/OrderServiceIntegrationTest.java
@@ -76,7 +76,7 @@ public class OrderServiceIntegrationTest {
                     new OrderCommand.OrderItem(product2.id(), 1L, product2.price())
             );
 
-            var orderCommand = new OrderCommand.Order(userInfo.id(), orderItems);
+            var orderCommand = new OrderCommand.Order(userInfo.id(), orderItems, null);
 
             // act
             OrderInfo orderInfo = orderService.createOrder(orderCommand);
@@ -103,8 +103,8 @@ public class OrderServiceIntegrationTest {
             var orderItems1 = List.of(new OrderCommand.OrderItem(product1.id(), 2L, product1.price()));
             var orderItems2 = List.of(new OrderCommand.OrderItem(product2.id(), 1L, product2.price()));
 
-            orderService.createOrder(new OrderCommand.Order(userInfo.id(), orderItems1));
-            orderService.createOrder(new OrderCommand.Order(userInfo.id(), orderItems2));
+            orderService.createOrder(new OrderCommand.Order(userInfo.id(), orderItems1, null));
+            orderService.createOrder(new OrderCommand.Order(userInfo.id(), orderItems2, null));
 
             // act
             List<OrderInfo> orderInfos = orderService.getOrders(userInfo.id());
@@ -132,7 +132,7 @@ public class OrderServiceIntegrationTest {
                     new OrderCommand.OrderItem(product1.id(), 2L, product1.price()),
                     new OrderCommand.OrderItem(product2.id(), 1L, product2.price())
             );
-            var orderCommand = new OrderCommand.Order(userInfo.id(), orderItems);
+            var orderCommand = new OrderCommand.Order(userInfo.id(), orderItems, null);
             var createdOrder = orderService.createOrder(orderCommand);
 
             // act

--- a/apps/commerce-api/src/test/java/com/loopers/domain/order/OrderServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/order/OrderServiceIntegrationTest.java
@@ -14,7 +14,8 @@ import com.loopers.domain.user.vo.Birth;
 import com.loopers.domain.user.vo.Email;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
-import jakarta.transaction.Transactional;
+import com.loopers.utils.DatabaseCleanUp;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -29,7 +30,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SpringBootTest
-@Transactional
 @DisplayName("OrderService 통합 테스트")
 public class OrderServiceIntegrationTest {
 
@@ -41,6 +41,15 @@ public class OrderServiceIntegrationTest {
     private BrandService brandService;
     @Autowired
     private ProductService productService;
+
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
 
     private UserInfo createUser() {
         var command = new UserCommand.SignUp("jinnie", "지은", Gender.FEMALE, Birth.of("1997-01-27"), Email.of("jinnie@naver.com")

--- a/apps/commerce-api/src/test/java/com/loopers/domain/point/PointServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/point/PointServiceIntegrationTest.java
@@ -9,7 +9,6 @@ import com.loopers.infrastructure.point.PointJpaRepository;
 import com.loopers.infrastructure.user.UserJpaRepository;
 import com.loopers.support.error.CoreException;
 import com.loopers.utils.DatabaseCleanUp;
-import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;

--- a/apps/commerce-api/src/test/java/com/loopers/domain/point/PointServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/point/PointServiceIntegrationTest.java
@@ -18,13 +18,16 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 @SpringBootTest
-@Transactional
 @DisplayName("PointService 통합 테스트")
 public class PointServiceIntegrationTest {
     /*
@@ -42,6 +45,8 @@ public class PointServiceIntegrationTest {
     private DatabaseCleanUp databaseCleanUp;
     @Autowired
     private PointJpaRepository pointJpaRepository;
+    @Autowired
+    private PointRepository pointRepository;
     @Autowired
     private UserJpaRepository userJpaRepository;
 
@@ -98,5 +103,46 @@ public class PointServiceIntegrationTest {
             assertThatThrownBy(() -> pointService.chargePoint(invalidId, 1000))
                     .isInstanceOf(CoreException.class);
         }
+    }
+
+    @Test
+    @DisplayName("여러 스레드가 동시에 포인트 차감 시, 중복 차감 없이 낙관적 락이 동작한다.")
+    void concurrentPointDeduction_optimisticLock() throws InterruptedException {
+        long userId = 1L;
+
+        int initialBalance = 10000;
+        int deductionAmount = 1000;
+
+        PointEntity point = new PointEntity(userId, initialBalance);
+        pointRepository.save(point);
+        int threadCount = 10;
+
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        AtomicInteger successCount = new AtomicInteger();
+        AtomicInteger failCount = new AtomicInteger();
+
+        for (int i = 0; i < threadCount; i++) {
+            executor.submit(() -> {
+                try {
+                    pointService.usePoints(userId, (long) deductionAmount);
+                    successCount.incrementAndGet();
+                } catch (Exception e) {
+                    failCount.incrementAndGet();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        PointEntity updated = pointRepository.findByUserId(userId).orElseThrow();
+        int expectedBalance = initialBalance - (deductionAmount * successCount.get());
+
+        assertThat(updated.getBalance()).isEqualTo(expectedBalance);
+        assertThat(successCount.get()).isLessThanOrEqualTo(threadCount);
+        assertThat(failCount.get()).isGreaterThan(0);
     }
 }

--- a/apps/commerce-api/src/test/java/com/loopers/domain/point/PointServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/point/PointServiceIntegrationTest.java
@@ -106,7 +106,7 @@ public class PointServiceIntegrationTest {
     }
 
     @Test
-    @DisplayName("여러 스레드가 동시에 포인트 차감 시, 중복 차감 없이 낙관적 락이 동작한다.")
+    @DisplayName("여러 스레드가 동시에 포인트 차감 시, 포인트가 중복 차감되지 않는다.")
     void concurrentPointDeduction_optimisticLock() throws InterruptedException {
         long userId = 1L;
 

--- a/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductServiceIntegrationTest.java
@@ -3,7 +3,6 @@ package com.loopers.domain.product;
 import com.loopers.domain.brand.BrandCommand;
 import com.loopers.domain.brand.BrandInfo;
 import com.loopers.domain.brand.BrandService;
-import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -13,7 +12,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest
-@Transactional
 @DisplayName("ProductService 통합 테스트")
 public class ProductServiceIntegrationTest {
 

--- a/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductTest.java
@@ -20,7 +20,7 @@ public class ProductTest {
         @DisplayName("상품 생성에 성공한다.")
         void createProduct_success() {
             //arrange
-            ProductEntity productEntity = new ProductEntity("shirt", 15000L, 100L, 1L);
+            ProductEntity productEntity = ProductEntity.of("shirt", 15000L, 100L, 1L);
 
             assertThat(productEntity.getStatus()).isEqualTo(ProductStatus.ON_SALE);
         }
@@ -29,7 +29,7 @@ public class ProductTest {
         @DisplayName("상품 이름이 null이면 BAD REQUEST 예외를 반환한다.")
         void fail_whenNameIsNull() {
             CoreException exception = assertThrows(CoreException.class, () ->
-                    new ProductEntity(null, 15000L, 100L, 1L));
+                    ProductEntity.of(null, 15000L, 100L, 1L));
 
             assertEquals(ErrorType.BAD_REQUEST, exception.getErrorType());
         }
@@ -38,7 +38,7 @@ public class ProductTest {
         @DisplayName("상품 가격이 음수이면 BAD REQUEST 예외를 반환한다.")
         void fail_whenPriceIsNegative() {
             CoreException exception = assertThrows(CoreException.class, () ->
-                    new ProductEntity("skirt", -1000L, 100L, 1L));
+                    ProductEntity.of("skirt", -1000L, 100L, 1L));
 
             assertEquals(ErrorType.BAD_REQUEST, exception.getErrorType());
         }
@@ -47,7 +47,7 @@ public class ProductTest {
         @DisplayName("상품 재고가 음수이면 BAD REQUEST 예외를 반환한다.")
         void fail_whenStockIsNegative() {
             CoreException exception = assertThrows(CoreException.class, () ->
-                    new ProductEntity("skirt", 15000L, -100L, 1L));
+                    ProductEntity.of("skirt", 15000L, -100L, 1L));
 
             assertEquals(ErrorType.BAD_REQUEST, exception.getErrorType());
         }

--- a/apps/commerce-api/src/test/java/com/loopers/domain/user/UserServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/user/UserServiceIntegrationTest.java
@@ -22,7 +22,6 @@ import static org.mockito.Mockito.verify;
 
 
 @SpringBootTest
-@Transactional
 @DisplayName("UserService 통합 테스트")
 public class UserServiceIntegrationTest {
 

--- a/apps/commerce-api/src/test/java/com/loopers/domain/userCoupon/UserCouponServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/userCoupon/UserCouponServiceIntegrationTest.java
@@ -1,0 +1,81 @@
+package com.loopers.domain.userCoupon;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UserCouponServiceIntegrationTest {
+
+    @Mock
+    UserCouponRepository userCouponRepository;
+
+    @InjectMocks
+    UserCouponService userCouponService;
+
+    @Test
+    @DisplayName("소유한 쿠폰이 ISSUED 상태라면 사용 처리한다")
+    void returnUsedStatus_whenIssuedCouponUsed() {
+        // arrange
+        var command = new UserCouponCommand.Use(1L, 10L);
+        var userCoupon = UserCouponEntity.of(1L, 10L); // ISSUED
+
+        when(userCouponRepository.findWithLockByUserIdAndCouponId(1L, 10L))
+                .thenReturn(Optional.of(userCoupon));
+
+        // act
+        userCouponService.useCoupon(command);
+
+        // assert
+        verify(userCouponRepository, times(1))
+                .findWithLockByUserIdAndCouponId(1L, 10L);
+        assertThat(userCoupon.getStatus()).isEqualTo(UserCouponStatus.USED);
+        assertThat(userCoupon.isUsed()).isTrue();
+    }
+
+    @Test
+    @DisplayName("소유하지 않은 쿠폰이면 NOT_FOUND 에러를 던진다")
+    void throwException_whenCouponNotOwned() {
+        // arrange
+        var command = new UserCouponCommand.Use(1L, 999L);
+        when(userCouponRepository.findWithLockByUserIdAndCouponId(1L, 999L))
+                .thenReturn(Optional.empty());
+
+        // act & assert
+        assertThatThrownBy(() -> userCouponService.useCoupon(command))
+                .isInstanceOf(CoreException.class)
+                .extracting("errorType")
+                .isEqualTo(ErrorType.NOT_FOUND);
+
+        verify(userCouponRepository).findWithLockByUserIdAndCouponId(1L, 999L);
+    }
+
+    @Test
+    @DisplayName("이미 사용된 쿠폰이면 BAD_REQUEST 에러를 던진다")
+    void throwException_whenAlreadyUsed() {
+        // arrange
+        var command = new UserCouponCommand.Use(1L, 10L);
+        var userCoupon = UserCouponEntity.of(1L, 10L);
+        userCoupon.use(); // USED
+
+        when(userCouponRepository.findWithLockByUserIdAndCouponId(1L, 10L))
+                .thenReturn(Optional.of(userCoupon));
+
+        // act & assert
+        assertThatThrownBy(() -> userCouponService.useCoupon(command))
+                .isInstanceOf(CoreException.class)
+                .extracting("errorType")
+                .isEqualTo(ErrorType.BAD_REQUEST);
+
+        verify(userCouponRepository).findWithLockByUserIdAndCouponId(1L, 10L);
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/userCoupon/UserCouponTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/userCoupon/UserCouponTest.java
@@ -1,0 +1,50 @@
+package com.loopers.domain.userCoupon;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.*;
+
+class UserCouponTest {
+
+    @Test
+    @DisplayName("발급 시 상태는 ISSUED 여야 한다")
+    void returnIssuedStatus_whenCreated() {
+        // arrange & act
+        var userCoupon = UserCouponEntity.of(1L, 10L);
+
+        // assert
+        assertThat(userCoupon.getUserId()).isEqualTo(1L);
+        assertThat(userCoupon.getCouponId()).isEqualTo(10L);
+        assertThat(userCoupon.getStatus()).isEqualTo(UserCouponStatus.ISSUED);
+        assertThat(userCoupon.isUsed()).isFalse();
+    }
+
+    @Test
+    @DisplayName("사용 전 상태(ISSUED)에서만 사용이 가능하며, 호출 후 USED 상태가 된다")
+    void returnUsedStatus_whenUseCalledFromIssued() {
+        // arrange
+        var userCoupon = UserCouponEntity.of(1L, 10L);
+
+        // act
+        userCoupon.use();
+
+        // assert
+        assertThat(userCoupon.getStatus()).isEqualTo(UserCouponStatus.USED);
+        assertThat(userCoupon.isUsed()).isTrue();
+    }
+
+    @Test
+    @DisplayName("이미 USED 상태에서 다시 use()를 호출하면 예외가 발생한다")
+    void throwException_whenUseCalledFromUsed() {
+        // arrange
+        var userCoupon = UserCouponEntity.of(1L, 10L);
+        userCoupon.use();
+
+        // act & assert
+        assertThatThrownBy(userCoupon::use)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("사용할 수 없는 쿠폰 상태입니다.");
+        assertThat(userCoupon.getStatus()).isEqualTo(UserCouponStatus.USED); // 상태 유지
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/api/brand/BrandV1ApiE2ETest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/api/brand/BrandV1ApiE2ETest.java
@@ -1,0 +1,88 @@
+package com.loopers.interfaces.api.brand;
+
+import com.loopers.domain.brand.BrandEntity;
+import com.loopers.domain.brand.BrandRepository;
+import com.loopers.interfaces.api.ApiResponse;
+import com.loopers.utils.DatabaseCleanUp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class BrandV1ApiE2ETest {
+    /*
+     * 브랜드 E2E 테스트
+     * - [x] 존재하는 브랜드 ID로 요청 시, 브랜드 정보를 응답한다.
+     * - [x] 존재하지 않는 브랜드 ID로 요청 시, 404 Not Found 응답을 반환한다.
+     */
+
+    private final TestRestTemplate testRestTemplate;
+    private final BrandRepository brandRepository;
+    private final DatabaseCleanUp databaseCleanUp;
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @Autowired
+    public BrandV1ApiE2ETest(TestRestTemplate testRestTemplate,BrandRepository brandRepository, DatabaseCleanUp databaseCleanUp) {
+       this.testRestTemplate = testRestTemplate;
+        this.brandRepository = brandRepository;
+        this.databaseCleanUp = databaseCleanUp;
+    }
+    private static final String ENDPOINT = "/api/v1/brands";
+
+    @DisplayName("GET /api/v1/brands/{brandId}")
+    @Nested
+    class getBrand {
+
+        @DisplayName("존재하는 브랜드 ID로 요청 시, 브랜드 정보를 응답한다.")
+        @Test
+        void returnsBrand_whenBrandIdExist(){
+            //arrange
+            BrandEntity brandEntity = new BrandEntity("나이키", "스포츠 브랜드");
+            brandRepository.save(brandEntity);
+            String requestUrl = ENDPOINT + "/" + brandEntity.getId();
+
+            //act
+            ParameterizedTypeReference<ApiResponse<BrandResponse>> responseType = new ParameterizedTypeReference<>() {};
+            ResponseEntity<ApiResponse<BrandResponse>> response =
+                    testRestTemplate.exchange(requestUrl, HttpMethod.GET, new HttpEntity<>(null), responseType);
+            //assert
+            assertAll(
+                    () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK),
+                    () -> assertThat(response.getBody()).isNotNull(),
+                    () -> assertThat(response.getBody().data().name()).isEqualTo(brandEntity.getName()),
+                    () -> assertThat(response.getBody().data().description()).isEqualTo(brandEntity.getDescription())
+            );
+        }
+
+        @DisplayName("존재하지 않는 브랜드 ID로 요청 시, 404 Not Found 응답을 반환한다.")
+        @Test
+        void returnsNotFound_whenBrandIdDoesNotExist(){
+            //arrange
+            Long invalidBrandId = 9999L;
+            String requestUrl = ENDPOINT + "/" + invalidBrandId;
+
+            //act
+            ParameterizedTypeReference<ApiResponse<BrandResponse>> responseType = new ParameterizedTypeReference<>() {};
+            ResponseEntity<ApiResponse<BrandResponse>> response =
+                    testRestTemplate.exchange(requestUrl, HttpMethod.GET, new HttpEntity<>(null), responseType);
+            //assert
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/api/coupon/CouponV1ApiE2ETest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/api/coupon/CouponV1ApiE2ETest.java
@@ -1,0 +1,216 @@
+package com.loopers.interfaces.api.coupon;
+
+import com.loopers.domain.coupon.CouponEntity;
+import com.loopers.domain.coupon.CouponRepository;
+import com.loopers.domain.coupon.DiscountType;
+import com.loopers.domain.userCoupon.UserCouponEntity;
+import com.loopers.domain.userCoupon.UserCouponRepository;
+import com.loopers.interfaces.api.ApiResponse;
+import com.loopers.utils.DatabaseCleanUp;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.*;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class CouponV1ApiE2ETest {
+
+    private static final long USER_ID = 1L;
+    private static final String ENDPOINT = "/api/v1/coupons";
+
+    private final TestRestTemplate testRestTemplate;
+    private final CouponRepository couponRepository;
+    private final UserCouponRepository userCouponRepository;
+    private final DatabaseCleanUp databaseCleanUp;
+
+    @Autowired
+    CouponV1ApiE2ETest(TestRestTemplate testRestTemplate, CouponRepository couponRepository, UserCouponRepository userCouponRepository, DatabaseCleanUp databaseCleanUp) {
+        this.testRestTemplate = testRestTemplate;
+        this.couponRepository = couponRepository;
+        this.userCouponRepository = userCouponRepository;
+        this.databaseCleanUp = databaseCleanUp;
+    }
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    private HttpHeaders jsonHeaders() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        return headers;
+    }
+
+    private CouponEntity saveFixedAmount(long amount, LocalDateTime expiredAt) {
+        CouponEntity coupon = CouponEntity.of("정액쿠폰", DiscountType.FIXED_AMOUNT, amount, null, expiredAt);
+        return couponRepository.save(coupon);
+    }
+
+    private CouponEntity saveFixedRate(double rate, LocalDateTime expiredAt) {
+        CouponEntity coupon = CouponEntity.of("정률쿠폰", DiscountType.FIXED_RATE, null, rate, expiredAt);
+        return couponRepository.save(coupon);
+    }
+
+    @Nested
+    @DisplayName("쿠폰 생성")
+    class Create {
+
+        @Test
+        @DisplayName("유효한 요청이면 200 OK와 생성된 쿠폰을 반환한다")
+        void returnsCoupon_whenCreateIsSuccessful() {
+            // arrange
+            var couponRequest = new CouponRequest.Create(
+                    "신규쿠폰",
+                    DiscountType.FIXED_AMOUNT,
+                    2_000L,
+                    null,
+                    LocalDateTime.now().plusDays(1).toString()
+            );
+            HttpEntity<CouponRequest.Create> entity = new HttpEntity<>(couponRequest, jsonHeaders());
+            ParameterizedTypeReference<ApiResponse<CouponResponse>> type = new ParameterizedTypeReference<>() {};
+
+            // act
+            ResponseEntity<ApiResponse<CouponResponse>> res =
+                    testRestTemplate.exchange(ENDPOINT, HttpMethod.POST, entity, type);
+
+            // assert
+            assertThat(res.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(res.getBody().data()).isNotNull();
+            assertThat(res.getBody().data().name()).isEqualTo("신규쿠폰");
+            assertThat(res.getBody().data().discountType()).isEqualTo(DiscountType.FIXED_AMOUNT.name());
+        }
+    }
+
+    @Nested
+    @DisplayName("쿠폰 조회")
+    class GetCoupon {
+
+        @Test
+        @DisplayName("사용 가능한 쿠폰이면 200 OK와 쿠폰 정보를 반환한다")
+        void returnsCoupon_whenAvailable() {
+            // arrange
+            var saved = saveFixedAmount(1_000L, LocalDateTime.now().plusDays(1));
+            String url = ENDPOINT + "/" + saved.getId();
+
+            HttpEntity<Void> entity = new HttpEntity<>(jsonHeaders());
+            ParameterizedTypeReference<ApiResponse<CouponResponse>> type = new ParameterizedTypeReference<>() {};
+
+            // act
+            var res = testRestTemplate.exchange(url, HttpMethod.GET, entity, type);
+
+            // assert
+            assertThat(res.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(res.getBody()).isNotNull();
+            assertThat(res.getBody().data()).isNotNull();
+            assertThat(res.getBody().data().couponId()).isEqualTo(saved.getId());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 쿠폰이면 404 Not Found를 반환한다")
+        void returnsNotFound_whenCouponDoesNotExist() {
+            // arrange
+            String url = ENDPOINT + "/999999";
+            HttpEntity<Void> entity = new HttpEntity<>(jsonHeaders());
+            ParameterizedTypeReference<ApiResponse<CouponResponse>> type = new ParameterizedTypeReference<>() {};
+
+            // act
+            var res = testRestTemplate.exchange(url, HttpMethod.GET, entity, type);
+
+            // assert
+            assertThat(res.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+            assertThat(res.getBody()).isNotNull();
+            assertThat(res.getBody().data()).isNull();
+        }
+
+        @Test
+        @DisplayName("만료된 쿠폰이면 400 Bad Request를 반환한다")
+        void returnsBadRequest_whenCouponExpired() {
+            // arrange
+            var expired = saveFixedAmount(1_000L, LocalDateTime.now().minusDays(1));
+            String url = ENDPOINT + "/" + expired.getId();
+
+            HttpEntity<Void> entity = new HttpEntity<>(jsonHeaders());
+            ParameterizedTypeReference<ApiResponse<CouponResponse>> type = new ParameterizedTypeReference<>() {};
+
+            // act
+            var res = testRestTemplate.exchange(url, HttpMethod.GET, entity, type);
+
+            // assert
+            assertThat(res.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+            assertThat(res.getBody()).isNotNull();
+            assertThat(res.getBody().data()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("쿠폰 할인 적용")
+    class ApplyCoupon {
+
+        @Test
+        @DisplayName("정액 쿠폰을 소유하고 있으면 할인된 금액을 반환한다")
+        void returnsDiscounted_whenFixedAmountAndOwned() {
+            // arrange
+            var coupon = saveFixedAmount(2_000L, LocalDateTime.now().plusDays(1));
+            userCouponRepository.save(UserCouponEntity.of(USER_ID, coupon.getId()));
+
+
+            var body = new CouponRequest.Apply(USER_ID, coupon.getId(), 10_000L);
+            HttpEntity<CouponRequest.Apply> entity = new HttpEntity<>(body, jsonHeaders());
+            ParameterizedTypeReference<ApiResponse<Long>> type = new ParameterizedTypeReference<>() {};
+
+            // act
+            var res = testRestTemplate.exchange(ENDPOINT + "/apply", HttpMethod.POST, entity, type);
+
+            // assert
+            assertThat(res.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(res.getBody()).isNotNull();
+            assertThat(res.getBody().data()).isEqualTo(8_000L);
+        }
+
+        @Test
+        @DisplayName("정률 쿠폰을 소유하고 있으면 할인 금액이 계산된다")
+        void returnsDiscounted_whenFixedRateAndOwned() {
+            // arrange
+            var coupon = saveFixedRate(0.10, LocalDateTime.now().plusDays(1)); // 10%
+            userCouponRepository.save(UserCouponEntity.of(USER_ID, coupon.getId()));
+
+            var body = new CouponRequest.Apply(USER_ID, coupon.getId(), 10_005L);
+            HttpEntity<CouponRequest.Apply> entity = new HttpEntity<>(body, jsonHeaders());
+            ParameterizedTypeReference<ApiResponse<Long>> type = new ParameterizedTypeReference<>() {};
+
+            // act
+            var res = testRestTemplate.exchange(ENDPOINT + "/apply", HttpMethod.POST, entity, type);
+
+            // assert
+            assertThat(res.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(res.getBody()).isNotNull();
+            assertThat(res.getBody().data()).isEqualTo((long) (10_005L * (1 - 0.10))); // 9004
+        }
+
+        @Test
+        @DisplayName("쿠폰을 소유하지 않으면 404 Not Found를 반환한다")
+        void returnsNotFound_whenCouponNotOwned() {
+            // arrange
+            var coupon = saveFixedAmount(1_000L, LocalDateTime.now().plusDays(1));
+
+            var body = new CouponRequest.Apply(USER_ID, coupon.getId(), 5_000L);
+            HttpEntity<CouponRequest.Apply> entity = new HttpEntity<>(body, jsonHeaders());
+            ParameterizedTypeReference<ApiResponse<Long>> type = new ParameterizedTypeReference<>() {};
+
+            // act
+            var res = testRestTemplate.exchange(ENDPOINT + "/apply", HttpMethod.POST, entity, type);
+
+            // assert
+            assertThat(res.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+            assertThat(res.getBody()).isNotNull();
+            assertThat(res.getBody().data()).isNull();
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/api/like/LikeV1ApiE2ETest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/api/like/LikeV1ApiE2ETest.java
@@ -1,0 +1,175 @@
+package com.loopers.interfaces.api.like;
+
+import com.loopers.domain.like.LikeEntity;
+import com.loopers.domain.like.LikeRepository;
+import com.loopers.domain.product.ProductEntity;
+import com.loopers.domain.product.ProductRepository;
+import com.loopers.interfaces.api.ApiResponse;
+import com.loopers.utils.DatabaseCleanUp;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.*;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class LikeV1ApiE2ETest  {
+    /*
+     * 좋아요 등록 E2E 테스트
+     * - [x] 좋아요가 등록되어 있지 않은 상태에서 요청 시, 200 OK를 반환한다.
+     * - [x] 이미 좋아요가 등록된 상태에서 다시 요청 시, 200 OK를 반환한다.
+     *
+     * 좋아요 취소 E2E 테스트
+     * - [x] 좋아요가 등록된 상태에서 취소 요청 시, 200 OK를 반환한다.
+     * - [x] 좋아요가 등록되지 않은 상태에서 취소 요청 시, 200 OK를 반환한다.
+     *
+     * 좋아요 목록 조회 E2E 테스트
+     * - [x] 유저가 좋아요한 상품 목록을 응답으로 반환한다.
+     */
+
+    private final TestRestTemplate testRestTemplate;
+    private final DatabaseCleanUp databaseCleanUp;
+    private final ProductRepository productRepository;
+    private final LikeRepository likeRepository;
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @Autowired
+    public LikeV1ApiE2ETest(TestRestTemplate testRestTemplate, ProductRepository productRepository, LikeRepository likeRepository ,DatabaseCleanUp databaseCleanUp) {
+        this.testRestTemplate = testRestTemplate;
+        this.productRepository = productRepository;
+        this.likeRepository = likeRepository;
+        this.databaseCleanUp = databaseCleanUp;
+    }
+    private static final String ENDPOINT = "/api/v1/likes/products";
+
+    private final Long userId = 1L;
+
+    private ProductEntity saveProduct() {
+        ProductEntity product = ProductEntity.of("상품명", 1000L, 10L, 1L);
+        return productRepository.save(product);
+    }
+    private HttpHeaders createHeaders() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("X-USER-ID", userId.toString());
+        return headers;
+    }
+
+    @Nested
+    @DisplayName("좋아요 등록")
+    class Like {
+
+        @Test
+        @DisplayName("좋아요가 등록되지 않은 상태에서 요청 시, 200 OK를 반환한다.")
+        void returnsSuccess_like_whenNotLiked() {
+            // arrange
+            ProductEntity product = saveProduct();
+            String requestUrl = ENDPOINT + "/" + product.getId();
+
+            HttpEntity<Void> entity = new HttpEntity<>(createHeaders());
+            ParameterizedTypeReference<ApiResponse<LikeResponse>> responseType = new ParameterizedTypeReference<>() {};
+
+            // act
+            ResponseEntity<ApiResponse<LikeResponse>> response =
+                    testRestTemplate.exchange(requestUrl, HttpMethod.POST, entity, responseType);
+
+            // assert
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(likeRepository.find(userId, product.getId())).isPresent();
+        }
+
+        @Test
+        @DisplayName("좋아요가 등록된 상태에서 요청 시, 200 OK를 반환한다.")
+        void returnsSuccess_like_whenLiked() {
+            // arrange
+            ProductEntity product = saveProduct();
+            likeRepository.save(LikeEntity.of(userId, product.getId()));
+            String requestUrl = ENDPOINT + "/" + product.getId();
+
+            HttpEntity<Void> entity = new HttpEntity<>(createHeaders());
+            ParameterizedTypeReference<ApiResponse<LikeResponse>> responseType = new ParameterizedTypeReference<>() {};
+
+            // act
+            ResponseEntity<ApiResponse<LikeResponse>> response =
+                    testRestTemplate.exchange(requestUrl, HttpMethod.POST, entity, responseType);
+
+            // assert
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(likeRepository.find(userId, product.getId())).isPresent();
+        }
+    }
+    @Nested
+    @DisplayName("좋아요 취소")
+    class UnlikeTest {
+
+        @Test
+        @DisplayName("좋아요가 등록된 상태에서 취소 요청 시, 200 OK를 반환한다.")
+        void returnsSuccess_unlike_whenLiked() {
+            ProductEntity product = saveProduct();
+            likeRepository.save(LikeEntity.of(userId, product.getId()));
+
+            String requestUrl = ENDPOINT + "/" + product.getId();
+            HttpEntity<Void> entity = new HttpEntity<>(createHeaders());
+            ParameterizedTypeReference<ApiResponse<LikeResponse>> responseType = new ParameterizedTypeReference<>() {};
+
+            ResponseEntity<ApiResponse<LikeResponse>> response =
+                    testRestTemplate.exchange(requestUrl, HttpMethod.DELETE, entity, responseType);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(likeRepository.find(userId, product.getId())).isNotPresent();
+        }
+
+        @Test
+        @DisplayName("좋아요가 등록되지 않은 상태에서 취소 요청 시, 200 OK를 반환한다.")
+        void returnsSuccess_unlike_whenNotLiked() {
+            ProductEntity product = saveProduct();
+
+            String requestUrl = ENDPOINT + "/" + product.getId();
+            HttpEntity<Void> entity = new HttpEntity<>(createHeaders());
+            ParameterizedTypeReference<ApiResponse<LikeResponse>> responseType = new ParameterizedTypeReference<>() {};
+
+            ResponseEntity<ApiResponse<LikeResponse>> response =
+                    testRestTemplate.exchange(requestUrl, HttpMethod.DELETE, entity, responseType);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(likeRepository.find(userId, product.getId())).isNotPresent();
+        }
+    }
+
+    @Nested
+    @DisplayName("좋아요 조회")
+    class getLikes {
+        @Test
+        @DisplayName("유저가 좋아요한 상품 목록을 응답으로 반환한다.")
+        void returnsLikedProductsByUserId() {
+            ProductEntity p1 = saveProduct();
+            ProductEntity p2 = saveProduct();
+            likeRepository.save(LikeEntity.of(userId, p1.getId()));
+            likeRepository.save(LikeEntity.of(userId, p2.getId()));
+
+            HttpEntity<Void> entity = new HttpEntity<>(createHeaders());
+            ParameterizedTypeReference<ApiResponse<List<LikeResponse>>> responseType = new ParameterizedTypeReference<>() {};
+
+            ResponseEntity<ApiResponse<List<LikeResponse>>> response =
+                    testRestTemplate.exchange(ENDPOINT, HttpMethod.GET, entity, responseType);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(response.getBody()).isNotNull();
+            assertThat(response.getBody().data())
+                    .extracting("productId")
+                    .containsExactlyInAnyOrder(p1.getId(), p2.getId());
+        }
+    }
+}
+

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/api/order/OrderV1ApiE2ETest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/api/order/OrderV1ApiE2ETest.java
@@ -1,0 +1,192 @@
+package com.loopers.interfaces.api.order;
+
+import com.loopers.domain.order.OrderCommand;
+import com.loopers.domain.point.PointEntity;
+import com.loopers.domain.point.PointRepository;
+import com.loopers.domain.product.ProductEntity;
+import com.loopers.domain.product.ProductRepository;
+import com.loopers.interfaces.api.ApiResponse;
+import com.loopers.utils.DatabaseCleanUp;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.*;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@DisplayName("Order API E2E 테스트")
+public class OrderV1ApiE2ETest {
+    /*
+     * 주문 생성 E2E 테스트
+     * - [x] 존재하는 상품으로 주문을 생성하면, 주문 정보가 반환된다.
+     * - [x] 재고보다 많은 수량을 주문할 경우, 400 Bad Request 응답을 반환한다.
+     * - [x] 존재하지 않는 상품으로 주문할 경우, 404 Not Found 응답을 반환한다.
+     *
+     * 주문 목록 조회 E2E 테스트
+     * - [x] 유저 ID로 요청 시, 주문 목록이 반환된다.
+     *
+     * 주문 상세 조회 E2E 테스트
+     * - [x] 존재하는 주문 ID 조회 시, 상세 주문 정보가 반환된다.
+     * - [x] 존재하지 않는 주문 ID 조회 시, 404 Not Found 응답을 반환한다.
+     */
+    private final TestRestTemplate testRestTemplate;
+    private final DatabaseCleanUp databaseCleanUp;
+    private final ProductRepository productRepository;
+    private final PointRepository pointRepository;
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @Autowired
+    public OrderV1ApiE2ETest(TestRestTemplate testRestTemplate, ProductRepository productRepository, PointRepository pointRepository, DatabaseCleanUp databaseCleanUp) {
+        this.testRestTemplate = testRestTemplate;
+        this.productRepository = productRepository;
+        this.pointRepository = pointRepository;
+        this.databaseCleanUp = databaseCleanUp;
+    }
+    private static final String ENDPOINT = "/api/v1/orders";
+
+    private final Long userId = 1L;
+
+    private ProductEntity createProduct(Long stock) {
+        return productRepository.save(ProductEntity.of("상품", 1000L, stock, 1L));
+    }
+
+    private HttpHeaders createHeaders() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("X-USER-ID", userId.toString());
+        return headers;
+    }
+
+    @Nested
+    @DisplayName("주문 생성")
+    class CreateOrder {
+
+        @Test
+        @DisplayName("존재하는 상품으로 주문을 생성하면, 주문 정보가 반환된다.")
+        void createOrder_success() {
+            //arrange
+            ProductEntity product = createProduct(10L);
+            pointRepository.save(new PointEntity(userId, 10000L));
+            OrderRequest.Create request = new OrderRequest.Create(
+                    List.of(new OrderCommand.OrderItem(product.getId(), 2L, product.getPrice()))
+            );
+            HttpEntity<OrderRequest.Create> entity = new HttpEntity<>(request, createHeaders());
+            ParameterizedTypeReference<ApiResponse<OrderResponse.Detail>> responseType = new ParameterizedTypeReference<>() {};
+
+            // act
+            ResponseEntity<ApiResponse<OrderResponse.Detail>> response =
+                    testRestTemplate.exchange(ENDPOINT, HttpMethod.POST, entity, responseType);
+
+            //assert
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(response.getBody()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("재고보다 많은 수량을 주문할 경우, 400 Bad Request 응답을 반환한다.")
+        void createOrder_exceedsStock() {
+            ProductEntity product = createProduct(1L);
+
+            OrderRequest.Create request = new OrderRequest.Create(
+                    List.of(new OrderCommand.OrderItem(product.getId(), 10L, product.getPrice()))
+            );
+            HttpEntity<OrderRequest.Create> entity = new HttpEntity<>(request, createHeaders());
+            ParameterizedTypeReference<ApiResponse<OrderResponse.Detail>> responseType = new ParameterizedTypeReference<>() {};
+
+            // act
+            ResponseEntity<ApiResponse<OrderResponse.Detail>> response =
+                    testRestTemplate.exchange(ENDPOINT, HttpMethod.POST, entity, responseType);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 상품으로 주문할 경우, 404 Not Found 응답을 반환한다.")
+        void createOrder_nonexistentProduct() {
+            OrderRequest.Create request = new OrderRequest.Create(
+                    List.of(new OrderCommand.OrderItem(9999L, 1L, 1000L))
+            );
+            HttpEntity<OrderRequest.Create> entity = new HttpEntity<>(request, createHeaders());
+
+            ResponseEntity<ApiResponse> response = testRestTemplate.postForEntity(ENDPOINT, entity, ApiResponse.class);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        }
+    }
+
+    @Nested
+    @DisplayName("주문 목록 조회")
+    class GetOrders {
+
+        @Test
+        @DisplayName("유저 ID로 요청 시, 주문 목록이 반환된다.")
+        void getOrders_success() {
+            ProductEntity product = createProduct(10L);
+            OrderRequest.Create request = new OrderRequest.Create(
+                    List.of(new OrderCommand.OrderItem(product.getId(), 1L, product.getPrice()))
+            );
+            HttpEntity<OrderRequest.Create> entity = new HttpEntity<>(request, createHeaders());
+            testRestTemplate.postForEntity(ENDPOINT, entity, ApiResponse.class);
+
+            ResponseEntity<ApiResponse> response = testRestTemplate.exchange(
+                    ENDPOINT, HttpMethod.GET, new HttpEntity<>(createHeaders()), ApiResponse.class);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(response.getBody()).isNotNull();
+            assertThat(response.getBody().data()).isNotNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("주문 상세 조회")
+    class GetOrder {
+
+        @Test
+        @DisplayName("존재하는 주문 ID 조회 시, 상세 주문 정보가 반환된다.")
+        void getOrder_success() {
+
+            ProductEntity product = createProduct(10L);
+            pointRepository.save(new PointEntity(userId, 10000L));
+            OrderRequest.Create request = new OrderRequest.Create(
+                    List.of(new OrderCommand.OrderItem(product.getId(), 1L, product.getPrice()))
+            );
+            HttpEntity<OrderRequest.Create> entity = new HttpEntity<>(request, createHeaders());
+            ParameterizedTypeReference<ApiResponse<OrderResponse.Detail>> responseType = new ParameterizedTypeReference<>() {};
+
+            ResponseEntity<ApiResponse<OrderResponse.Detail>> createdResponse = testRestTemplate.exchange(
+                    ENDPOINT, HttpMethod.POST, entity, responseType
+            );
+            Long orderId = createdResponse.getBody().data().orderId();
+            //act
+            HttpEntity<Void> getEntity = new HttpEntity<>(createHeaders());
+            ResponseEntity<ApiResponse<OrderResponse.Detail>> response = testRestTemplate.exchange(
+                    ENDPOINT + "/" + orderId, HttpMethod.GET, getEntity, responseType
+            );
+            // assert
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(response.getBody()).isNotNull();
+            assertThat(response.getBody().data().orderId()).isEqualTo(orderId);
+            assertThat(response.getBody().data().orderItems()).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 주문 ID 조회 시, 404 Not Found 응답을 반환한다.")
+        void getOrder_notFound() {
+            ResponseEntity<ApiResponse> response = testRestTemplate.exchange(
+                    ENDPOINT + "/99999", HttpMethod.GET, new HttpEntity<>(createHeaders()), ApiResponse.class);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/api/order/OrderV1ApiE2ETest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/api/order/OrderV1ApiE2ETest.java
@@ -79,7 +79,7 @@ public class OrderV1ApiE2ETest {
             ProductEntity product = createProduct(10L);
             pointRepository.save(new PointEntity(userId, 10000L));
             OrderRequest.Create request = new OrderRequest.Create(
-                    List.of(new OrderCommand.OrderItem(product.getId(), 2L, product.getPrice()))
+                    List.of(new OrderCommand.OrderItem(product.getId(), 2L, product.getPrice())), null
             );
             HttpEntity<OrderRequest.Create> entity = new HttpEntity<>(request, createHeaders());
             ParameterizedTypeReference<ApiResponse<OrderResponse.Detail>> responseType = new ParameterizedTypeReference<>() {};
@@ -99,7 +99,7 @@ public class OrderV1ApiE2ETest {
             ProductEntity product = createProduct(1L);
 
             OrderRequest.Create request = new OrderRequest.Create(
-                    List.of(new OrderCommand.OrderItem(product.getId(), 10L, product.getPrice()))
+                    List.of(new OrderCommand.OrderItem(product.getId(), 10L, product.getPrice())), null
             );
             HttpEntity<OrderRequest.Create> entity = new HttpEntity<>(request, createHeaders());
             ParameterizedTypeReference<ApiResponse<OrderResponse.Detail>> responseType = new ParameterizedTypeReference<>() {};
@@ -115,7 +115,7 @@ public class OrderV1ApiE2ETest {
         @DisplayName("존재하지 않는 상품으로 주문할 경우, 404 Not Found 응답을 반환한다.")
         void createOrder_nonexistentProduct() {
             OrderRequest.Create request = new OrderRequest.Create(
-                    List.of(new OrderCommand.OrderItem(9999L, 1L, 1000L))
+                    List.of(new OrderCommand.OrderItem(9999L, 1L, 1000L)), null
             );
             HttpEntity<OrderRequest.Create> entity = new HttpEntity<>(request, createHeaders());
 
@@ -134,7 +134,7 @@ public class OrderV1ApiE2ETest {
         void getOrders_success() {
             ProductEntity product = createProduct(10L);
             OrderRequest.Create request = new OrderRequest.Create(
-                    List.of(new OrderCommand.OrderItem(product.getId(), 1L, product.getPrice()))
+                    List.of(new OrderCommand.OrderItem(product.getId(), 1L, product.getPrice())), null
             );
             HttpEntity<OrderRequest.Create> entity = new HttpEntity<>(request, createHeaders());
             testRestTemplate.postForEntity(ENDPOINT, entity, ApiResponse.class);
@@ -159,7 +159,7 @@ public class OrderV1ApiE2ETest {
             ProductEntity product = createProduct(10L);
             pointRepository.save(new PointEntity(userId, 10000L));
             OrderRequest.Create request = new OrderRequest.Create(
-                    List.of(new OrderCommand.OrderItem(product.getId(), 1L, product.getPrice()))
+                    List.of(new OrderCommand.OrderItem(product.getId(), 1L, product.getPrice())), null
             );
             HttpEntity<OrderRequest.Create> entity = new HttpEntity<>(request, createHeaders());
             ParameterizedTypeReference<ApiResponse<OrderResponse.Detail>> responseType = new ParameterizedTypeReference<>() {};

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/api/point/PointV1ApiE2ETest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/api/point/PointV1ApiE2ETest.java
@@ -70,7 +70,7 @@ public class PointV1ApiE2ETest {
             pointJpaRepository.save(pointEntity);
 
             HttpHeaders headers = new HttpHeaders();
-            headers.add("X-USER-ID", userEntity.getUserId());
+            headers.set("X-USER-ID", String.valueOf(userEntity.getId()));
             HttpEntity<Object> requestEntity = new HttpEntity<>(headers);
 
             //act
@@ -83,7 +83,6 @@ public class PointV1ApiE2ETest {
                     () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK),
                     () -> assertThat(response.getBody().data().balance()).isEqualTo(pointEntity.getBalance())
             );
-
         }
 
         @DisplayName("X-USER-ID 헤더가 없을 경우, 400 Bad Request 응답을 반환한다.")
@@ -116,10 +115,9 @@ public class PointV1ApiE2ETest {
             //arrange
             UserEntity userEntity = new UserEntity("jinnie", "지은", Gender.FEMALE, Birth.of("1997-01-27"), Email.of("jinnie@naver.com"));
             userJpaRepository.save(userEntity);
-            pointJpaRepository.save(new PointEntity(1000,userEntity.getId()));
-
+            pointJpaRepository.save(new PointEntity(userEntity.getId(),1000L));
             HttpHeaders headers = new HttpHeaders();
-            headers.add("X-USER-ID", userEntity.getUserId());
+            headers.add("X-USER-ID", String.valueOf(userEntity.getId()));
             headers.setContentType(MediaType.APPLICATION_JSON);
 
             PointRequest.PointChargeRequest request = new PointRequest.PointChargeRequest(1000);
@@ -142,7 +140,7 @@ public class PointV1ApiE2ETest {
         void returnsNotFound_whenUserDoesNotExist() {
             //arrange
             HttpHeaders headers = new HttpHeaders();
-            headers.set("X-USER-ID", "non_existent_user");
+            headers.set("X-USER-ID", String.valueOf(999_999L));
             headers.setContentType(MediaType.APPLICATION_JSON);
 
             PointRequest.PointChargeRequest request = new PointRequest.PointChargeRequest(1000);
@@ -161,4 +159,4 @@ public class PointV1ApiE2ETest {
             );
         }
     }
-    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/api/product/ProductV1ApiE2ETest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/api/product/ProductV1ApiE2ETest.java
@@ -1,0 +1,135 @@
+package com.loopers.interfaces.api.product;
+
+import com.loopers.domain.brand.BrandEntity;
+import com.loopers.domain.brand.BrandRepository;
+import com.loopers.domain.like.LikeEntity;
+import com.loopers.domain.like.LikeRepository;
+import com.loopers.domain.product.ProductEntity;
+import com.loopers.domain.product.ProductRepository;
+import com.loopers.interfaces.api.ApiResponse;
+import com.loopers.utils.DatabaseCleanUp;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@DisplayName("Product API E2E 테스트")
+public class ProductV1ApiE2ETest {
+    /*
+     * 상품  조회 E2E 테스트
+     * - [x] 상품 목록을 최신순으로 정렬 시, 최근에 등록한 순서로 반환한다.
+     * - [x] 상품 목록을 좋아요 순으로 정렬 시, 좋아요가 많은 순서로 반환한다.
+     * - [x] 상품 목록을 가격이 낮은 순으로 정렬 시, 가격이 낮은 순서로 반환한다.
+     */
+    private final TestRestTemplate testRestTemplate;
+    private final DatabaseCleanUp databaseCleanUp;
+    private final ProductRepository productRepository;
+    private final BrandRepository brandRepository;
+    private final LikeRepository likeRepository;
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @Autowired
+    public ProductV1ApiE2ETest(TestRestTemplate testRestTemplate, ProductRepository productRepository, BrandRepository brandRepository, LikeRepository likeRepository, DatabaseCleanUp databaseCleanUp) {
+        this.testRestTemplate = testRestTemplate;
+        this.productRepository = productRepository;
+        this.brandRepository = brandRepository;
+        this.likeRepository = likeRepository;
+        this.databaseCleanUp = databaseCleanUp;
+    }
+    private static final String ENDPOINT = "/api/v1/products";
+
+    private final Long userId = 1L;
+
+    private BrandEntity saveBrand() {
+        return brandRepository.save(BrandEntity.of("브랜드", "설명"));
+    }
+
+    private ProductEntity saveProduct(String name, Long price) {
+        ProductEntity product = ProductEntity.of(name, price, 100L, saveBrand().getId());
+        productRepository.save(product);
+        return product;
+    }
+
+    private void like(ProductEntity product, int count) {
+        for (int i = 0; i < count; i++) {
+            likeRepository.save(LikeEntity.of((long) i + 100, product.getId()));
+        }
+    }
+
+    private HttpHeaders createHeaders() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("X-USER-ID", userId.toString());
+        return headers;
+    }
+
+    @Test
+    @DisplayName("상품의 등록일이 가장 최근인 순서로 상품 목록 조회시, 상품 목록 리스트를 가장 최근에 등록한 상품 순서로 반환한다.")
+    void getProducts_sortedByLatest_success() throws InterruptedException {
+        ProductEntity oldProduct = productRepository.save(ProductEntity.of("상품1", 1000L, 10L, saveBrand().getId()));
+        Thread.sleep(10);
+        ProductEntity newProduct = productRepository.save(ProductEntity.of("상품2", 2000L, 10L, saveBrand().getId()));
+
+        String url = ENDPOINT + "?sort=LATEST";
+        ResponseEntity<ApiResponse<List<ProductResponse>>> response = testRestTemplate.exchange(
+                url, HttpMethod.GET, new HttpEntity<>(null, createHeaders()), new ParameterizedTypeReference<>() {}
+        );
+
+        List<ProductResponse> result = response.getBody().data();
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).id()).isEqualTo(newProduct.getId());
+        assertThat(result.get(1).id()).isEqualTo(oldProduct.getId());
+    }
+
+    @Test
+    @DisplayName("가격 오름차순 정렬 시 가장 저렴한 상품이 먼저 조회된다")
+    void getProducts_sortedByPriceAsc() {
+        saveProduct("Expensive", 5000L);
+        saveProduct("Cheap", 1000L);
+
+        ResponseEntity<ApiResponse<List<ProductResponse>>> response = testRestTemplate.exchange(
+                ENDPOINT + "?sort=PRICE_ASC", HttpMethod.GET, new HttpEntity<>(createHeaders()), new ParameterizedTypeReference<>() {}
+        );
+
+        List<ProductResponse> result = response.getBody().data();
+
+        assertThat(result).isNotEmpty();
+        assertThat(result.get(0).name()).isEqualTo("Cheap");
+        assertThat(result.get(1).name()).isEqualTo("Expensive");
+    }
+
+    @Test
+    @DisplayName("좋아요 수 내림차순 정렬 시 가장 좋아요 많은 상품이 먼저 조회된다")
+    void getProducts_sortedByLikesDesc() {
+        ProductEntity fewLikes = saveProduct("FewLikes", 1000L);
+        ProductEntity manyLikes = saveProduct("ManyLikes", 1000L);
+
+        like(fewLikes, 1);
+        like(manyLikes, 3);
+
+        ResponseEntity<ApiResponse<List<ProductResponse>>> response = testRestTemplate.exchange(
+                ENDPOINT + "?sort=LIKES_DESC", HttpMethod.GET, new HttpEntity<>(createHeaders()), new ParameterizedTypeReference<>() {}
+        );
+
+        List<ProductResponse> result = response.getBody().data();
+
+        assertThat(result).isNotEmpty();
+        assertThat(result.get(0).name()).isEqualTo("ManyLikes");
+        assertThat(result.get(1).name()).isEqualTo("FewLikes");
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 ### Project Group ###
 projectGroup=com.loopers
 ### Project dependency versions ###
-=2.0.20
+kotlinVersion=2.0.20
 ### Plugin dependency versions ###
 ktLintPluginVersion=12.1.2
 ktLintVersion=1.0.1

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -27,10 +27,4 @@ pluginManagement {
             }
         }
     }
-    plugins {
-        kotlin("jvm") version "2.2.0"
-    }
-}
-plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
 }


### PR DESCRIPTION
## 📌 Summary
- Brand, Like, Product, Order E2E 테스트
- 쿠폰 도메인 구현
- 포인트 차감, 상품 재고 차감, 쿠폰 사용에 비관적 락 적용
- 좋아요 기능에 유니크키 설정으로 멱등성 보장
- ## 💬 Review Points
### 1. 테스트 경계
- 각 계층(도메인, 애플리케이션, 인터페이스) 테스트 코드의 위치와 범위가 적절한지 궁금합니다.
현재 도메인별· 계층별 경계가 불명확하고, 특히 도메인별 파사드 테스트 코드가 뒤섞여 있는 느낌이라 전체적으로 구조 수정이 필요하다고 생각합니다..

### 2. 쿠폰 설계
- Coupon과 별도로 UserCoupon 엔티티를 두어 발급 및 상태 관리 로직을 분리했습니다. 이 방식이 적절한지, 아니면 불필요하게 복잡성을 높이는 구조인지 궁금합니다.

### 3. 좋아요 멱등성
- 좋아요 수는 동시 변경 시 데이터 불일치 위험이 적고, 실시간으로 DB의 `count(*)`로 조회하므로 별도의 락 없이 `(user_id, product_id)` 유니크키로만 멱등성을 보장했습니다. 이러한 접근이 적절한지, 아니면 예외 상황까지 대비해 락을 적용하는 편이 더 나은지 궁금합니다.

### 4. 트랜잭션 적용 범위
- 테스트 과정에서 잦은 Lazy 로딩 및 세션 문제가 발생하여, @Transactional을 최소한으로 적용하되, 쓰기 메서드에는 일반 @Transactional을, 조회 메서드에는 @Transactional(readOnly = true)를 적용하는 방식으로 Facade와 Service를 구성했습니다.
이 접근 방식이 적절한지, 추가적인 리팩토링이 필요한지 궁금합니다.

## ✅ Checklist
### 🗞️ Coupon 도메인

- [x]  쿠폰은 사용자가 소유하고 있으며, 이미 사용된 쿠폰은 사용할 수 없어야 한다.
- [x]  쿠폰 종류는 정액 / 정률로 구분되며, 각 적용 로직을 구현하였다.
- [x]  각 발급된 쿠폰은 최대 한번만 사용될 수 있다.

### 🧾 **주문**

- [x]  주문 전체 흐름에 대해 원자성이 보장되어야 한다.
- [x]  사용 불가능하거나 존재하지 않는 쿠폰일 경우 주문은 실패해야 한다.
- [x]  재고가 존재하지 않거나 부족할 경우 주문은 실패해야 한다.
- [x]  주문 시 유저의 포인트 잔액이 부족할 경우 주문은 실패해야 한다
- [x]  쿠폰, 재고, 포인트 처리 등 하나라도 작업이 실패하면 모두 롤백처리되어야 한다.
- [x]  주문 성공 시, 모든 처리는 정상 반영되어야 한다.

### 🧪 동시성 테스트

- [x]  동일한 상품에 대해 여러명이 좋아요/싫어요를 요청해도, 상품의 좋아요 개수가 정상 반영되어야 한다.
- [x]  동일한 쿠폰으로 여러 기기에서 동시에 주문해도, 쿠폰은 단 한번만 사용되어야 한다.
- [x]  동일한 유저가 서로 다른 주문을 동시에 수행해도, 포인트가 정상적으로 차감되어야 한다.
- [x]  동일한 상품에 대해 여러 주문이 동시에 요청되어도, 재고가 정상적으로 차감되어야 한다.
