### PR TITLE
[volume-8] 카프카 기반 이벤트 파이프라인 구현

### DIFF
--- a/apps/commerce-api/build.gradle.kts
+++ b/apps/commerce-api/build.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:${project.properties["springDocOpenApiVersion"]}")
+    implementation("org.springframework.kafka:spring-kafka")
 
     // Feign Client
     implementation("org.springframework.cloud:spring-cloud-starter-openfeign")

--- a/apps/commerce-api/build.gradle.kts
+++ b/apps/commerce-api/build.gradle.kts
@@ -2,6 +2,7 @@ dependencies {
     // add-ons
     implementation(project(":modules:jpa"))
     implementation(project(":modules:redis"))
+    implementation(project(":modules:kafka"))
     implementation(project(":supports:jackson"))
     implementation(project(":supports:logging"))
     implementation(project(":supports:monitoring"))
@@ -27,4 +28,5 @@ dependencies {
     // test-fixtures
     testImplementation(testFixtures(project(":modules:jpa")))
     testImplementation(testFixtures(project(":modules:redis")))
+    testImplementation(testFixtures(project(":modules:kafka")))
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/event/LikeCountUpdated.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/event/LikeCountUpdated.java
@@ -1,0 +1,20 @@
+package com.loopers.domain.event;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record LikeCountUpdated(
+        String eventId,
+        Long productId,
+        long likeCount,
+        Instant updatedAt
+) {
+    public static LikeCountUpdated of(Long productId, long likeCount) {
+        return new LikeCountUpdated(
+                UUID.randomUUID().toString(),
+                productId,
+                likeCount,
+                Instant.now()
+        );
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/event/OrderCreatedEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/event/OrderCreatedEvent.java
@@ -10,4 +10,8 @@ public record OrderCreatedEvent(
         PaymentMethod method,
         String cardType,
         String cardNo
-) {}
+) {
+    public static OrderCreatedEvent of(Long orderId, Long userId, long totalAmount, Long couponId) {
+        return new OrderCreatedEvent(orderId, userId, totalAmount, couponId, null, null, null);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductEntity.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductEntity.java
@@ -73,4 +73,10 @@ public class ProductEntity extends BaseEntity implements Serializable {
         }
         this.stock += quantity;
     }
+
+    public void setLikeCount(long likeCount) {
+        if (likeCount < 0) likeCount = 0;
+        this.likeCount = likeCount;
+    }
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/event/StockAdjusted.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/event/StockAdjusted.java
@@ -1,0 +1,16 @@
+package com.loopers.domain.product.event;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record StockAdjusted(
+        String eventId,
+        Long productId,
+        long newStock,
+        long delta,
+        Instant updatedAt
+) {
+    public static StockAdjusted of(Long productId, long newStock, long delta) {
+        return new StockAdjusted(UUID.randomUUID().toString(), productId, newStock, delta, Instant.now());
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/kafka/AfterCommitKafkaBridge.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/kafka/AfterCommitKafkaBridge.java
@@ -1,0 +1,98 @@
+package com.loopers.infrastructure.kafka;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.loopers.domain.event.LikeCountUpdated;
+import com.loopers.domain.order.event.OrderCreatedEvent;
+import com.loopers.domain.product.event.StockAdjusted;
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.springframework.transaction.event.TransactionPhase.AFTER_COMMIT;
+
+@Component
+@RequiredArgsConstructor
+public class AfterCommitKafkaBridge {
+
+    private static final String TOPIC = "catalog-events";
+    private static final String ORDER_TOPIC   = "order-events";
+
+    private final KafkaTemplate<Object, Object> kafka;
+    private final ObjectMapper om = new ObjectMapper();
+
+    @TransactionalEventListener(phase = AFTER_COMMIT)
+    public void on(LikeCountUpdated e) {
+        try {
+            String key = e.productId().toString();
+            String json = om.writeValueAsString(Map.of(
+                    "eventId",     e.eventId(),
+                    "eventType",   "LIKE_CHANGED",
+                    "aggregateType","PRODUCT",
+                    "aggregateId", key,
+                    "updatedAt",   e.updatedAt().toString(),
+                    "producerApp", "commerce-api",
+                    "payload",     Map.of("likeCount", e.likeCount())
+            ));
+
+            kafka.send(TOPIC, key, json).get();
+
+        } catch (Exception ex) {
+            throw new RuntimeException("Kafka publish failed", ex);
+        }
+    }
+
+    @TransactionalEventListener(phase = AFTER_COMMIT)
+    public void on(StockAdjusted e) {
+        try {
+            String key = e.productId().toString();
+            String json = om.writeValueAsString(Map.of(
+                    "eventId",      e.eventId(),
+                    "eventType",    "STOCK_ADJUSTED",
+                    "aggregateType","PRODUCT",
+                    "aggregateId",  key,
+                    "updatedAt",    e.updatedAt().toString(),
+                    "producerApp",  "commerce-api",
+                    "payload",      Map.of("newStock", e.newStock()
+                    )
+            ));
+            kafka.send(TOPIC, key, json).get();
+        } catch (Exception ex) {
+            throw new RuntimeException("Kafka publish failed", ex);
+        }
+    }
+    @TransactionalEventListener(phase = AFTER_COMMIT)
+    public void on(OrderCreatedEvent e) {
+        try {
+            String key = e.orderId().toString();
+
+            // payload는 null 가능성이 있어 Map.of 대신 가변 Map 사용
+            Map<String, Object> payload = new HashMap<>();
+            payload.put("userId",      e.userId());
+            payload.put("totalAmount", e.totalAmount());
+            payload.put("couponId",    e.couponId());
+            payload.put("method",      e.method() != null ? e.method().name() : null);
+            payload.put("cardType",    e.cardType());
+
+            String json = om.writeValueAsString(Map.of(
+                    "eventId",       UUID.randomUUID().toString(),
+                    "eventType",     "ORDER_CREATED",
+                    "aggregateType", "ORDER",
+                    "aggregateId",   key,
+                    "updatedAt",     Instant.now().toString(),
+                    "producerApp",   "commerce-api",
+                    "payload",       payload
+            ));
+
+            kafka.send(ORDER_TOPIC, key, json).get();
+        } catch (Exception ex) {
+            throw new RuntimeException("Kafka publish failed", ex);
+        }
+    }
+
+}

--- a/apps/commerce-api/src/main/resources/application.yml
+++ b/apps/commerce-api/src/main/resources/application.yml
@@ -21,6 +21,7 @@ spring:
     import:
       - jpa.yml
       - redis.yml
+      - kafka.yml
       - logging.yml
       - monitoring.yml
 
@@ -28,6 +29,11 @@ springdoc:
   use-fqn: true
   swagger-ui:
     path: /swagger-ui.html
+
+  kafka:
+    properties:
+      auto:
+        create.topics.enable: true
 
 ---
 spring:

--- a/apps/commerce-api/src/main/resources/application.yml
+++ b/apps/commerce-api/src/main/resources/application.yml
@@ -24,6 +24,14 @@ spring:
       - kafka.yml
       - logging.yml
       - monitoring.yml
+  kafka:
+    bootstrap-servers: localhost:9092   # ← active 프로필에서 이 값이 실제로 로드되는지!
+    producer:
+      acks: all
+      properties:
+        enable.idempotence: true
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
 
 springdoc:
   use-fqn: true

--- a/apps/commerce-streamer/build.gradle.kts
+++ b/apps/commerce-streamer/build.gradle.kts
@@ -1,0 +1,23 @@
+dependencies {
+    // add-ons
+    implementation(project(":modules:jpa"))
+    implementation(project(":modules:redis"))
+    implementation(project(":modules:kafka"))
+    implementation(project(":supports:jackson"))
+    implementation(project(":supports:logging"))
+    implementation(project(":supports:monitoring"))
+
+    // web
+    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
+
+    // querydsl
+    annotationProcessor("com.querydsl:querydsl-apt::jakarta")
+    annotationProcessor("jakarta.persistence:jakarta.persistence-api")
+    annotationProcessor("jakarta.annotation:jakarta.annotation-api")
+
+    // test-fixtures
+    testImplementation(testFixtures(project(":modules:jpa")))
+    testImplementation(testFixtures(project(":modules:redis")))
+    testImplementation(testFixtures(project(":modules:kafka")))
+}

--- a/apps/commerce-streamer/build.gradle.kts
+++ b/apps/commerce-streamer/build.gradle.kts
@@ -10,6 +10,7 @@ dependencies {
     // web
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
+    implementation("org.springframework.kafka:spring-kafka")
 
     // querydsl
     annotationProcessor("com.querydsl:querydsl-apt::jakarta")

--- a/apps/commerce-streamer/src/main/java/com/loopers/CommerceStreamerApplication.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/CommerceStreamerApplication.java
@@ -1,0 +1,24 @@
+package com.loopers;
+
+import jakarta.annotation.PostConstruct;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+
+import java.util.TimeZone;
+
+@SpringBootApplication
+@ConfigurationPropertiesScan
+public class CommerceStreamerApplication {
+
+    @PostConstruct
+    public void started() {
+        // set timezone
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+    }
+
+    public static void main(String[] args) {
+        SpringApplication.run(CommerceStreamerApplication.class, args);
+    }
+
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/config/KafkaConsumerConfig.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/config/KafkaConsumerConfig.java
@@ -1,0 +1,33 @@
+package com.loopers.config;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.listener.ContainerProperties;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+@EnableKafka
+public class KafkaConsumerConfig {
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, String> manualAckFactory() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
+
+        var factory = new ConcurrentKafkaListenerContainerFactory<String, String>();
+        factory.setConsumerFactory(new DefaultKafkaConsumerFactory<>(props));
+        factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.MANUAL_IMMEDIATE);
+        factory.setConcurrency(3); // 파티션 수
+        return factory;
+    }
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/audit/AuditCommand.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/audit/AuditCommand.java
@@ -1,0 +1,3 @@
+package com.loopers.domain.audit;
+
+public record AuditCommand(String eventId, String topic, String key, String payloadJson) {}

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/audit/AuditService.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/audit/AuditService.java
@@ -1,0 +1,16 @@
+package com.loopers.domain.audit;
+
+import com.loopers.infrastructure.audit.EventLogJpaEntity;
+import com.loopers.infrastructure.audit.EventLogJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuditService {
+    private final EventLogJpaRepository eventLogRepo;
+
+    public void append(AuditCommand cmd) {
+        eventLogRepo.save(EventLogJpaEntity.of(cmd.eventId(), cmd.topic(), cmd.key(), cmd.payloadJson()));
+    }
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/audit/AuditService.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/audit/AuditService.java
@@ -2,6 +2,9 @@ package com.loopers.domain.audit;
 
 import com.loopers.infrastructure.audit.EventLogJpaEntity;
 import com.loopers.infrastructure.audit.EventLogJpaRepository;
+import com.loopers.infrastructure.event.EventHandledJpaEntity;
+import com.loopers.infrastructure.event.EventHandledJpaRepository;
+import com.loopers.infrastructure.event.EventHandledKey;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -9,8 +12,13 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class AuditService {
     private final EventLogJpaRepository eventLogRepo;
+    private final EventHandledJpaRepository handledRepo;
+    private static final String HANDLER = "AUDIT";
 
-    public void append(AuditCommand cmd) {
+    public void appendIfFirst(AuditCommand cmd) {
+        var key = new EventHandledKey(cmd.eventId(), HANDLER);
+        if (handledRepo.existsById(key)) return;
         eventLogRepo.save(EventLogJpaEntity.of(cmd.eventId(), cmd.topic(), cmd.key(), cmd.payloadJson()));
+        handledRepo.save(EventHandledJpaEntity.of(cmd.eventId(), HANDLER));
     }
 }

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/cache/CacheEvictService.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/cache/CacheEvictService.java
@@ -1,0 +1,32 @@
+package com.loopers.domain.cache;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CacheEvictService {
+
+    private final StringRedisTemplate redis;
+    @Value("${app.cache.product-detail}") private String productDetail;
+    @Value("${app.cache.product-list}")   private String productList;
+
+    public void onLikeChanged(long productId) {
+        evictDetail(productId);
+        evictListAll();
+    }
+    public void onStockAdjusted(long productId) {
+        evictDetail(productId);
+        evictListAll();
+    }
+
+    private void evictDetail(long productId) {
+        redis.delete(productDetail + ":" + productId);
+    }
+    private void evictListAll() {
+        var keys = redis.keys(productList + "*");
+        if (keys != null && !keys.isEmpty()) redis.delete(keys);
+    }
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/product/ProductMetricsService.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/product/ProductMetricsService.java
@@ -1,0 +1,39 @@
+package com.loopers.domain.product;
+
+import com.loopers.infrastructure.event.EventHandledJpaEntity;
+import com.loopers.infrastructure.event.EventHandledKey;
+import com.loopers.infrastructure.event.EventHandledJpaRepository;
+import com.loopers.infrastructure.product.ProductMetricsEntity;
+import com.loopers.infrastructure.product.ProductMetricsJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+
+@Service
+@RequiredArgsConstructor
+public class ProductMetricsService {
+    private final ProductMetricsJpaRepository snapshotJpaRepository;
+    private final EventHandledJpaRepository eventHandledJpaRepository;
+
+    private static final String HANDLER = "METRICS";
+
+    @Transactional
+    public void handleLikeChanged(String eventId, long productId, long likeCount, Instant updatedAt) {
+
+        var key = new EventHandledKey(eventId, HANDLER);
+        if (eventHandledJpaRepository.existsById(key)) return;
+
+        var snap = snapshotJpaRepository.findById(productId).orElse(null);
+        if (snap != null && updatedAt.isBefore(snap.getLastUpdatedAt())) {
+            eventHandledJpaRepository.save(EventHandledJpaEntity.of(eventId, HANDLER));
+            return;
+        }
+
+        if (snap == null) snapshotJpaRepository.save(ProductMetricsEntity.of(productId, likeCount, updatedAt));
+        else { snap.apply(likeCount, updatedAt); snapshotJpaRepository.save(snap); }
+
+        eventHandledJpaRepository.save(EventHandledJpaEntity.of(eventId, HANDLER));
+    }
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/product/ProductMetricsService.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/product/ProductMetricsService.java
@@ -3,6 +3,7 @@ package com.loopers.domain.product;
 import com.loopers.infrastructure.event.EventHandledJpaEntity;
 import com.loopers.infrastructure.event.EventHandledKey;
 import com.loopers.infrastructure.event.EventHandledJpaRepository;
+import com.loopers.infrastructure.product.ProductMetricsDailyJpaRepository;
 import com.loopers.infrastructure.product.ProductMetricsEntity;
 import com.loopers.infrastructure.product.ProductMetricsJpaRepository;
 import lombok.RequiredArgsConstructor;
@@ -10,14 +11,21 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
 public class ProductMetricsService {
     private final ProductMetricsJpaRepository snapshotJpaRepository;
+    private final ProductMetricsDailyJpaRepository dailyRepository;
     private final EventHandledJpaRepository eventHandledJpaRepository;
 
     private static final String HANDLER = "METRICS";
+    private static final ZoneId ZONE = ZoneId.of("Asia/Seoul");
 
     @Transactional
     public void handleLikeChanged(String eventId, long productId, long likeCount, Instant updatedAt) {
@@ -31,8 +39,33 @@ public class ProductMetricsService {
             return;
         }
 
+        long prev = (snap == null) ? 0 : snap.getLikeCount();
+        long delta = likeCount - prev;
+
+        if (delta != 0) {
+            LocalDate d = LocalDateTime.ofInstant(updatedAt, ZONE).toLocalDate();
+            dailyRepository.upsertDaily(d, productId, delta, 0, updatedAt.truncatedTo(ChronoUnit.MILLIS));
+        }
+
         if (snap == null) snapshotJpaRepository.save(ProductMetricsEntity.of(productId, likeCount, updatedAt));
         else { snap.apply(likeCount, updatedAt); snapshotJpaRepository.save(snap); }
+
+        eventHandledJpaRepository.save(EventHandledJpaEntity.of(eventId, HANDLER));
+    }
+
+    @Transactional
+    public void handleStockAdjusted(String eventId, long productId, Long deltaNullable, java.time.Instant updatedAt) {
+
+        var key = new EventHandledKey(eventId, HANDLER);
+        if (eventHandledJpaRepository.existsById(key)) return;
+
+        long delta = Objects.requireNonNullElse(deltaNullable, 0L);
+        long sales = (delta < 0) ? -delta : 0;
+
+        if (sales > 0) {
+            LocalDate d = LocalDateTime.ofInstant(updatedAt, ZONE).toLocalDate();
+            dailyRepository.upsertDaily(d, productId, 0, sales, updatedAt);
+        }
 
         eventHandledJpaRepository.save(EventHandledJpaEntity.of(eventId, HANDLER));
     }

--- a/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/audit/EventLogJpaEntity.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/audit/EventLogJpaEntity.java
@@ -1,0 +1,19 @@
+package com.loopers.infrastructure.audit;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name="event_log")
+@Getter
+@NoArgsConstructor
+public class EventLogJpaEntity {
+    @Id
+    @GeneratedValue(strategy= GenerationType.IDENTITY) private Long id;
+    private String eventId;
+    private String topic;
+    private String keyStr;
+    @Lob private String payloadJson;
+    public static EventLogJpaEntity of(String e,String t,String k,String j){ var x=new EventLogJpaEntity(); x.eventId=e;x.topic=t;x.keyStr=k;x.payloadJson=j; return x; }
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/audit/EventLogJpaRepository.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/audit/EventLogJpaRepository.java
@@ -1,0 +1,6 @@
+package com.loopers.infrastructure.audit;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EventLogJpaRepository extends JpaRepository<EventLogJpaEntity, Long> {
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/event/EventHandledJpaEntity.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/event/EventHandledJpaEntity.java
@@ -1,0 +1,25 @@
+package com.loopers.infrastructure.event;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name="event_handled")
+@IdClass(EventHandledKey.class)
+@Getter
+@NoArgsConstructor
+public class EventHandledJpaEntity {
+    @Id
+    @Column(name="event_id")     private String eventId;
+    @Id @Column(name="handler_name") private String handlerName;
+    @Column(name="processed_at", nullable=false) private LocalDateTime processedAt;
+
+    public static EventHandledJpaEntity of(String eventId, String handler){
+        var e = new EventHandledJpaEntity();
+        e.eventId = eventId; e.handlerName = handler; e.processedAt = LocalDateTime.now();
+        return e;
+    }
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/event/EventHandledJpaEntity.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/event/EventHandledJpaEntity.java
@@ -13,9 +13,12 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 public class EventHandledJpaEntity {
     @Id
-    @Column(name="event_id")     private String eventId;
-    @Id @Column(name="handler_name") private String handlerName;
-    @Column(name="processed_at", nullable=false) private LocalDateTime processedAt;
+    @Column(name="event_id")
+    private String eventId;
+    @Id @Column(name="handler_name")
+    private String handlerName;
+    @Column(name="processed_at", nullable=false)
+    private LocalDateTime processedAt;
 
     public static EventHandledJpaEntity of(String eventId, String handler){
         var e = new EventHandledJpaEntity();

--- a/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/event/EventHandledJpaRepository.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/event/EventHandledJpaRepository.java
@@ -1,0 +1,8 @@
+package com.loopers.infrastructure.event;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface EventHandledJpaRepository extends JpaRepository<EventHandledJpaEntity, EventHandledKey> {}
+

--- a/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/event/EventHandledKey.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/event/EventHandledKey.java
@@ -1,0 +1,14 @@
+package com.loopers.infrastructure.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class EventHandledKey implements Serializable {
+    private String eventId;
+    private String handlerName;
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/product/ProductMetricsDailyEntity.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/product/ProductMetricsDailyEntity.java
@@ -1,0 +1,36 @@
+package com.loopers.infrastructure.product;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.Instant;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "product_metrics")
+public class ProductMetricsDailyEntity {
+
+    @EmbeddedId
+    private ProductMetricsDailyKey id;
+
+    @Column(name = "like_delta", nullable = false)
+    private long likeDelta;
+
+    @Column(name = "sales_qty", nullable = false)
+    private long salesQty;
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    public static ProductMetricsDailyEntity of(long productId, java.time.LocalDate date,
+                                               long likeDelta, long salesQty, Instant updatedAt) {
+        return ProductMetricsDailyEntity.builder()
+                .id(new ProductMetricsDailyKey(date, productId))
+                .likeDelta(likeDelta)
+                .salesQty(salesQty)
+                .updatedAt(updatedAt)
+                .build();
+    }
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/product/ProductMetricsDailyJpaRepository.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/product/ProductMetricsDailyJpaRepository.java
@@ -1,0 +1,33 @@
+package com.loopers.infrastructure.product;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.time.LocalDate;
+
+@Repository
+public interface ProductMetricsDailyJpaRepository extends JpaRepository<ProductMetricsDailyEntity, ProductMetricsDailyKey> {
+
+    @Modifying
+    @Transactional
+    @Query(value = """
+        INSERT INTO product_metrics(metric_date, product_id, like_delta, sales_qty, updated_at)
+        VALUES (:metricDate, :productId, :likeDelta, :salesQty, :updatedAt)
+        ON DUPLICATE KEY UPDATE
+          like_delta = like_delta + VALUES(like_delta),
+          sales_qty  = sales_qty  + VALUES(sales_qty),
+          updated_at = GREATEST(updated_at, VALUES(updated_at))
+        """, nativeQuery = true)
+    void upsertDaily(
+            @Param("metricDate") LocalDate metricDate,
+            @Param("productId") long productId,
+            @Param("likeDelta") long likeDelta,
+            @Param("salesQty") long salesQty,
+            @Param("updatedAt") Instant updatedAt
+    );
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/product/ProductMetricsDailyKey.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/product/ProductMetricsDailyKey.java
@@ -1,4 +1,4 @@
-package com.loopers.infrastructure.event;
+package com.loopers.infrastructure.product;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
@@ -8,16 +8,19 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.io.Serializable;
+import java.time.LocalDate;
 
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
 @Embeddable
 @EqualsAndHashCode
-public class EventHandledKey implements Serializable {
+public class ProductMetricsDailyKey implements Serializable {
 
-    @Column(name = "event_id", nullable = false)
-    private String eventId;
-    @Column(name = "handler_name", nullable = false)
-    private String handlerName;
+    @Column(name = "metric_date", nullable = false)
+    private LocalDate metricDate;
+
+    @Column(name = "product_id", nullable = false)
+    private Long productId;
+
 }

--- a/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/product/ProductMetricsEntity.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/product/ProductMetricsEntity.java
@@ -1,0 +1,35 @@
+package com.loopers.infrastructure.product;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+@Entity
+@Table(name="product_metrics_snapshot")
+@Getter
+@NoArgsConstructor
+public class ProductMetricsEntity {
+    @Id
+    private Long productId;
+    private long likeCount;
+    private Instant lastUpdatedAt;
+
+    private ProductMetricsEntity(Long productId, long likeCount, Instant lastUpdatedAt) {
+        this.productId = productId;
+        this.likeCount = likeCount;
+        this.lastUpdatedAt = lastUpdatedAt;
+    }
+
+    public static ProductMetricsEntity of(Long productId, long likeCount, Instant updatedAt) {
+        return new ProductMetricsEntity(productId, likeCount, updatedAt);
+    }
+
+    public void apply(long likeCount, Instant updatedAt){
+        if (lastUpdatedAt!=null && updatedAt.isBefore(lastUpdatedAt)) return;
+        this.likeCount = likeCount; this.lastUpdatedAt = updatedAt;
+    }
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/product/ProductMetricsJpaRepository.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/product/ProductMetricsJpaRepository.java
@@ -1,0 +1,6 @@
+package com.loopers.infrastructure.product;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductMetricsJpaRepository extends JpaRepository<ProductMetricsEntity, Long> {
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/audit/AuditKafkaConsumer.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/audit/AuditKafkaConsumer.java
@@ -1,0 +1,51 @@
+package com.loopers.interfaces.consumer.audit;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.loopers.domain.audit.AuditCommand;
+import com.loopers.domain.audit.AuditService;
+import lombok.RequiredArgsConstructor;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AuditKafkaConsumer {
+    private final ObjectMapper om = new ObjectMapper();
+    private final AuditService audit;
+
+    @KafkaListener(topics={"catalog-events"}, groupId="audit-consumer", containerFactory="manualAckFactory")
+    public void on(@Payload String json, @Header(KafkaHeaders.RECEIVED_TOPIC) String topic,
+                   ConsumerRecord<String,String> rec, Acknowledgment ack){
+        try {
+
+            if (json == null || json.isBlank()) {
+                ack.acknowledge();
+                return;
+            }
+
+            JsonNode n = om.readTree(json);
+            if (n.isTextual()) {
+                n = om.readTree(n.asText());
+            }
+
+            String eventId = null;
+            if (n.hasNonNull("eventId")) eventId = n.get("eventId").asText();
+            else if (n.path("metadata").hasNonNull("eventId")) eventId = n.path("metadata").get("eventId").asText();
+            if (eventId == null) {
+                eventId = "kafka:%s:%d:%d".formatted(rec.topic(), rec.partition(), rec.offset());
+            }
+
+            audit.append(new AuditCommand(eventId, topic, rec.key(), n.toString()));
+
+            ack.acknowledge();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/audit/AuditKafkaConsumer.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/audit/AuditKafkaConsumer.java
@@ -1,6 +1,5 @@
 package com.loopers.interfaces.consumer.audit;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.loopers.domain.audit.AuditCommand;
 import com.loopers.domain.audit.AuditService;
@@ -8,9 +7,6 @@ import lombok.RequiredArgsConstructor;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.support.Acknowledgment;
-import org.springframework.kafka.support.KafkaHeaders;
-import org.springframework.messaging.handler.annotation.Header;
-import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -19,30 +15,21 @@ public class AuditKafkaConsumer {
     private final ObjectMapper om = new ObjectMapper();
     private final AuditService audit;
 
-    @KafkaListener(topics={"catalog-events"}, groupId="audit-consumer", containerFactory="manualAckFactory")
-    public void on(@Payload String json, @Header(KafkaHeaders.RECEIVED_TOPIC) String topic,
-                   ConsumerRecord<String,String> rec, Acknowledgment ack){
+    @KafkaListener(topics={"catalog-events", "order-events"}, groupId="audit-consumer", containerFactory="manualAckFactory")
+    public void on(ConsumerRecord<String,String> rec, Acknowledgment ack){
         try {
+            String json = rec.value();
+            if (json == null || json.isBlank()) { ack.acknowledge(); return; }
 
-            if (json == null || json.isBlank()) {
-                ack.acknowledge();
-                return;
-            }
+            var n = om.readTree(json);
+            if (n.isTextual()) n = om.readTree(n.asText());
 
-            JsonNode n = om.readTree(json);
-            if (n.isTextual()) {
-                n = om.readTree(n.asText());
-            }
-
-            String eventId = null;
-            if (n.hasNonNull("eventId")) eventId = n.get("eventId").asText();
-            else if (n.path("metadata").hasNonNull("eventId")) eventId = n.path("metadata").get("eventId").asText();
+            String eventId = n.path("eventId").asText(null);
             if (eventId == null) {
                 eventId = "kafka:%s:%d:%d".formatted(rec.topic(), rec.partition(), rec.offset());
             }
 
-            audit.append(new AuditCommand(eventId, topic, rec.key(), n.toString()));
-
+            audit.appendIfFirst(new AuditCommand(eventId, rec.topic(), rec.key(), n.toString()));
             ack.acknowledge();
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/cache/CacheKafkaConsumer.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/cache/CacheKafkaConsumer.java
@@ -1,0 +1,43 @@
+package com.loopers.interfaces.consumer.cache;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.loopers.domain.cache.CacheEvictService;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CacheKafkaConsumer {
+    private final ObjectMapper om;
+    private final CacheEvictService cache;
+
+    public CacheKafkaConsumer(ObjectMapper om, CacheEvictService cache) {
+        this.om = om;
+        this.cache = cache;
+    }
+
+    @KafkaListener(topics="catalog-events", groupId="cache-consumer", containerFactory="manualAckFactory")
+    public void on(ConsumerRecord<String,String> rec, Acknowledgment ack){
+        try {
+            String json = rec.value();
+            if (json == null || json.isBlank()) { ack.acknowledge(); return; }
+
+            var n = om.readTree(json);
+            if (n.isTextual()) n = om.readTree(n.asText());
+
+            String type = n.path("eventType").asText("");
+            String aggIdStr = n.path("aggregateId").asText(null);
+            long productId  = (aggIdStr != null) ? Long.parseLong(aggIdStr) : n.path("aggregateId").asLong();
+
+            switch (type) {
+                case "LIKE_CHANGED"   -> cache.onLikeChanged(productId);
+                case "STOCK_ADJUSTED" -> cache.onStockAdjusted(productId);
+                default -> { }
+            }
+            ack.acknowledge();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/product/ProductKafkaConsumer.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/product/ProductKafkaConsumer.java
@@ -1,0 +1,49 @@
+package com.loopers.interfaces.consumer.product;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.loopers.domain.product.ProductMetricsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+
+@Component
+@RequiredArgsConstructor
+public class ProductKafkaConsumer {
+    private final ObjectMapper om = new ObjectMapper();
+    private final ProductMetricsService metrics;
+
+    @KafkaListener(topics="catalog-events", groupId="metrics-consumer", containerFactory="manualAckFactory")
+    public void on(@Payload String json, Acknowledgment ack){
+        try {
+            if (json == null || json.isBlank()) { ack.acknowledge(); return; }
+
+            JsonNode n = om.readTree(json);
+            if (n.isTextual()) {
+                n = om.readTree(n.asText());
+            }
+
+            if (!"LIKE_CHANGED".equals(n.path("eventType").asText())) {
+                ack.acknowledge(); return;
+            }
+
+            String eventId   = n.path("eventId").asText(null);
+            String aggIdStr  = n.path("aggregateId").asText(null);
+            long productId   = aggIdStr != null ? Long.parseLong(aggIdStr) : n.path("aggregateId").asLong(); // "1014"도 안전
+            long likeCount   = n.path("payload").path("likeCount").asLong();
+            Instant updatedAt= Instant.parse(n.path("updatedAt").asText());
+
+            // 멱등/최신성 체크는 서비스에서 수행
+            metrics.handleLikeChanged(eventId != null ? eventId : "kafka:catalog-events::",
+                    productId, likeCount, updatedAt);
+
+            ack.acknowledge();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/product/ProductKafkaConsumer.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/product/ProductKafkaConsumer.java
@@ -25,19 +25,29 @@ public class ProductKafkaConsumer {
             var n = om.readTree(json);
             if (n.isTextual()) n = om.readTree(n.asText());
 
-            if (!"LIKE_CHANGED".equals(n.path("eventType").asText())) { ack.acknowledge(); return; }
-
+            String type = n.path("eventType").asText("");
             String eventId = n.path("eventId").asText(null);
-            if (eventId == null) {
-                eventId = "kafka:%s:%d:%d".formatted(rec.topic(), rec.partition(), rec.offset());
-            }
+            if (eventId == null) eventId = "kafka:%s:%d:%d".formatted(rec.topic(), rec.partition(), rec.offset());
 
-            String aggIdStr   = n.path("aggregateId").asText(null);
-            long productId    = (aggIdStr != null) ? Long.parseLong(aggIdStr) : n.path("aggregateId").asLong();
-            long likeCount    = n.path("payload").path("likeCount").asLong();
+            long productId = n.path("aggregateId").isTextual()
+                    ? Long.parseLong(n.path("aggregateId").asText())
+                    : n.path("aggregateId").asLong();
+
             Instant updatedAt = Instant.parse(n.path("updatedAt").asText());
 
-            metrics.handleLikeChanged(eventId, productId, likeCount, updatedAt);
+            switch (type) {
+                case "LIKE_CHANGED" -> {
+                    long likeCount = n.path("payload").path("likeCount").asLong();
+                    metrics.handleLikeChanged(eventId, productId, likeCount, updatedAt);
+                }
+                case "STOCK_ADJUSTED" -> {
+                    Long delta = n.path("payload").path("delta").isMissingNode()
+                            ? null : n.path("payload").path("delta").asLong();
+                    metrics.handleStockAdjusted(eventId, productId, delta, updatedAt);
+                }
+                default -> { /* ignore others */ }
+            }
+
             ack.acknowledge();
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/product/ProductKafkaConsumer.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/product/ProductKafkaConsumer.java
@@ -1,12 +1,11 @@
 package com.loopers.interfaces.consumer.product;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.loopers.domain.product.ProductMetricsService;
 import lombok.RequiredArgsConstructor;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.support.Acknowledgment;
-import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.stereotype.Component;
 
 import java.time.Instant;
@@ -18,29 +17,27 @@ public class ProductKafkaConsumer {
     private final ProductMetricsService metrics;
 
     @KafkaListener(topics="catalog-events", groupId="metrics-consumer", containerFactory="manualAckFactory")
-    public void on(@Payload String json, Acknowledgment ack){
+    public void on(ConsumerRecord<String,String> rec, Acknowledgment ack){
         try {
+            String json = rec.value();
             if (json == null || json.isBlank()) { ack.acknowledge(); return; }
 
-            JsonNode n = om.readTree(json);
-            if (n.isTextual()) {
-                n = om.readTree(n.asText());
+            var n = om.readTree(json);
+            if (n.isTextual()) n = om.readTree(n.asText());
+
+            if (!"LIKE_CHANGED".equals(n.path("eventType").asText())) { ack.acknowledge(); return; }
+
+            String eventId = n.path("eventId").asText(null);
+            if (eventId == null) {
+                eventId = "kafka:%s:%d:%d".formatted(rec.topic(), rec.partition(), rec.offset());
             }
 
-            if (!"LIKE_CHANGED".equals(n.path("eventType").asText())) {
-                ack.acknowledge(); return;
-            }
+            String aggIdStr   = n.path("aggregateId").asText(null);
+            long productId    = (aggIdStr != null) ? Long.parseLong(aggIdStr) : n.path("aggregateId").asLong();
+            long likeCount    = n.path("payload").path("likeCount").asLong();
+            Instant updatedAt = Instant.parse(n.path("updatedAt").asText());
 
-            String eventId   = n.path("eventId").asText(null);
-            String aggIdStr  = n.path("aggregateId").asText(null);
-            long productId   = aggIdStr != null ? Long.parseLong(aggIdStr) : n.path("aggregateId").asLong(); // "1014"도 안전
-            long likeCount   = n.path("payload").path("likeCount").asLong();
-            Instant updatedAt= Instant.parse(n.path("updatedAt").asText());
-
-            // 멱등/최신성 체크는 서비스에서 수행
-            metrics.handleLikeChanged(eventId != null ? eventId : "kafka:catalog-events::",
-                    productId, likeCount, updatedAt);
-
+            metrics.handleLikeChanged(eventId, productId, likeCount, updatedAt);
             ack.acknowledge();
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/apps/commerce-streamer/src/main/resources/application.yml
+++ b/apps/commerce-streamer/src/main/resources/application.yml
@@ -1,0 +1,60 @@
+server:
+  shutdown: graceful
+  tomcat:
+    threads:
+      max: 200 # 최대 워커 스레드 수 (default : 200)
+      min-spare: 10 # 최소 유지 스레드 수 (default : 10)
+    connection-timeout: 1m # 연결 타임아웃 (ms) (default : 60000ms = 1m)
+    max-connections: 8192 # 최대 동시 연결 수 (default : 8192)
+    accept-count: 100 # 대기 큐 크기 (default : 100)
+    keep-alive-timeout: 60s # 60s
+  max-http-request-header-size: 8KB
+
+spring:
+  main:
+    web-application-type: servlet
+  application:
+    name: commerce-streamer
+  profiles:
+    active: local
+  config:
+    import:
+      - application-jpa.yml
+      - application-redis.yml
+      - application-kafka.yml
+      - application-logging.yml
+      - application-monitoring.yml
+
+demo-kafka:
+  test:
+    topic-name: demo.internal.topic-v1
+
+---
+
+spring.config.activate.on-profile: local, test
+
+server:
+  port: 8084
+
+management:
+  server:
+    port: 8085
+
+---
+
+spring.config.activate.on-profile: dev
+
+server:
+  port: 8084
+
+management:
+  server:
+    port: 8085
+
+---
+
+spring.config.activate.on-profile: qa
+
+---
+
+spring.config.activate.on-profile: prd

--- a/apps/commerce-streamer/src/main/resources/application.yml
+++ b/apps/commerce-streamer/src/main/resources/application.yml
@@ -19,42 +19,57 @@ spring:
     active: local
   config:
     import:
-      - application-jpa.yml
-      - application-redis.yml
-      - application-kafka.yml
-      - application-logging.yml
-      - application-monitoring.yml
+      - jpa.yml
+      - logging.yml
+      - monitoring.yml
+  datasource:
+    url: jdbc:mysql://localhost:3306/loopers
+    username: application
+    password: application
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    hibernate:
+      ddl-auto: update
 
-demo-kafka:
-  test:
-    topic-name: demo.internal.topic-v1
+springdoc:
+  use-fqn: true
+  swagger-ui:
+    path: /swagger-ui.html
 
 ---
-
-spring.config.activate.on-profile: local, test
-
+spring:
+  config:
+    activate:
+      on-profile: local, test
+  kafka:
+    properties:
+      auto:
+        create.topics.enable: true
 server:
   port: 8084
 
 management:
   server:
-    port: 8085
+    port: 8087
 
 ---
-
-spring.config.activate.on-profile: dev
-
-server:
-  port: 8084
-
-management:
-  server:
-    port: 8085
+spring:
+  config:
+    activate:
+      on-profile: dev
 
 ---
-
-spring.config.activate.on-profile: qa
+spring:
+  config:
+    activate:
+      on-profile: qa
 
 ---
+spring:
+  config:
+    activate:
+      on-profile: prd
 
-spring.config.activate.on-profile: prd
+springdoc:
+  api-docs:
+    enabled: false

--- a/apps/commerce-streamer/src/main/resources/application.yml
+++ b/apps/commerce-streamer/src/main/resources/application.yml
@@ -41,6 +41,10 @@ spring:
   config:
     activate:
       on-profile: local, test
+  data:
+    redis:
+      host: localhost
+      port: 6379
   kafka:
     properties:
       auto:
@@ -52,6 +56,10 @@ management:
   server:
     port: 8087
 
+app:
+  cache:
+    product-detail: product:detail
+    product-list:  product:list
 ---
 spring:
   config:

--- a/apps/commerce-streamer/src/test/java/com/loopers/domain/cache/CacheEvictServiceTest.java
+++ b/apps/commerce-streamer/src/test/java/com/loopers/domain/cache/CacheEvictServiceTest.java
@@ -1,0 +1,64 @@
+package com.loopers.domain.cache;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CacheEvictServiceTest {
+
+    @Mock
+    StringRedisTemplate redis;
+    CacheEvictService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new CacheEvictService(redis);
+        ReflectionTestUtils.setField(service, "productDetail", "product:detail");
+        ReflectionTestUtils.setField(service, "productList",   "product:list");
+    }
+
+    @Test
+    void onLikeChanged_should_delete_detail_and_list() {
+        long productId = 1014L;
+
+        when(redis.keys("product:list*"))
+                .thenReturn(Set.of("product:list:all", "product:list:page:1"));
+
+        service.onLikeChanged(productId);
+
+        // 상세키 삭제 확인
+        verify(redis).delete("product:detail:" + productId);
+
+        // 목록키 일괄 삭제 확인
+        ArgumentCaptor<Set<String>> captor = ArgumentCaptor.forClass(Set.class);
+        verify(redis).delete(captor.capture());
+        assertThat(captor.getValue()).containsExactlyInAnyOrder("product:list:all", "product:list:page:1");
+
+        verifyNoMoreInteractions(redis);
+    }
+
+    @Test
+    void onStockAdjusted_should_delete_detail_and_list_even_when_no_list_keys() {
+        long productId = 2002L;
+
+        when(redis.keys("product:list*")).thenReturn(Set.of());
+
+        service.onStockAdjusted(productId);
+
+        verify(redis).delete("product:detail:" + productId);
+
+        verify(redis, never()).delete(Set.of());
+        verifyNoMoreInteractions(redis);
+    }
+}

--- a/apps/commerce-streamer/src/test/java/com/loopers/domain/cache/CacheEvictServiceTest.java
+++ b/apps/commerce-streamer/src/test/java/com/loopers/domain/cache/CacheEvictServiceTest.java
@@ -29,7 +29,7 @@ class CacheEvictServiceTest {
     }
 
     @Test
-    void onLikeChanged_should_delete_detail_and_list() {
+    void shouldEvictDetailAndList_onLikeChanged() {
         long productId = 1014L;
 
         when(redis.keys("product:list*"))
@@ -49,7 +49,7 @@ class CacheEvictServiceTest {
     }
 
     @Test
-    void onStockAdjusted_should_delete_detail_and_list_even_when_no_list_keys() {
+    void shouldEvictDetailAndList_onStockAdjusted_whenNoListKeys() {
         long productId = 2002L;
 
         when(redis.keys("product:list*")).thenReturn(Set.of());

--- a/apps/commerce-streamer/src/test/java/com/loopers/domain/product/ProductMetricsServiceTest.java
+++ b/apps/commerce-streamer/src/test/java/com/loopers/domain/product/ProductMetricsServiceTest.java
@@ -1,0 +1,131 @@
+package com.loopers.domain.product;
+
+import com.loopers.infrastructure.event.EventHandledJpaEntity;
+import com.loopers.infrastructure.event.EventHandledJpaRepository;
+import com.loopers.infrastructure.event.EventHandledKey;
+import com.loopers.infrastructure.product.ProductMetricsDailyJpaRepository;
+import com.loopers.infrastructure.product.ProductMetricsEntity;
+import com.loopers.infrastructure.product.ProductMetricsJpaRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class ProductMetricsServiceTest {
+    @Mock
+    ProductMetricsJpaRepository productMetricsJpaRepository;
+    @Mock
+    ProductMetricsDailyJpaRepository productMetricsDailyJpaRepository;
+    @Mock
+    EventHandledJpaRepository eventHandledJpaRepository;
+
+    ProductMetricsService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new ProductMetricsService(productMetricsJpaRepository, productMetricsDailyJpaRepository, eventHandledJpaRepository);
+    }
+
+    @Test
+    void shouldUpsertLikeDeltaAndSnapshot_onFirstLikeEvent() {
+        String eventId = "like-1";
+        long productId = 1014L;
+        long likeCount = 7L;
+        Instant updatedAt = Instant.parse("2025-09-05T06:00:00Z");
+        LocalDate dayKst = LocalDateTime.ofInstant(updatedAt, ZoneId.of("Asia/Seoul")).toLocalDate();
+
+        when(eventHandledJpaRepository.existsById(new EventHandledKey(eventId, "METRICS"))).thenReturn(false);
+        when(productMetricsJpaRepository.findById(productId)).thenReturn(java.util.Optional.empty());
+
+        service.handleLikeChanged(eventId, productId, likeCount, updatedAt);
+
+        // upsertDaily(like +7, sales 0)
+        verify(productMetricsDailyJpaRepository).upsertDaily(eq(dayKst), eq(productId), eq(7L), eq(0L), eq(updatedAt));
+
+        verify(productMetricsJpaRepository).save(argThat(s ->
+                s.getProductId().equals(productId)
+                        && s.getLikeCount() == 7L
+                        && s.getLastUpdatedAt().equals(updatedAt)
+        ));
+
+        verify(eventHandledJpaRepository).save(argThat(e ->
+                e.getEventId() != null
+                        && "METRICS".equals(e.getHandlerName())
+                        && eventId.equals(e.getEventId())
+        ));
+    }
+
+    @Test
+    void shouldSkipUpsert_butMarkHandled_onOutOfOrderLikeEvent() {
+        String eventId = "like-old";
+        long productId = 1014L;
+        long likeCount = 5L;
+        Instant oldTs = Instant.parse("2025-09-05T06:00:00Z");
+        Instant newTs = Instant.parse("2025-09-05T08:00:00Z");
+
+        var snap = ProductMetricsEntity.of(productId, 10L, newTs);
+        when(eventHandledJpaRepository.existsById(new EventHandledKey(eventId, "METRICS"))).thenReturn(false);
+        when(productMetricsJpaRepository.findById(productId)).thenReturn(java.util.Optional.of(snap));
+
+        service.handleLikeChanged(eventId, productId, likeCount, oldTs);
+
+        verifyNoInteractions(productMetricsDailyJpaRepository);
+        verify(eventHandledJpaRepository).save(argThat(e ->
+                e.getEventId() != null
+                        && "METRICS".equals(e.getHandlerName())
+                        && eventId.equals(e.getEventId())
+        ));
+    }
+
+    @Test
+    void shouldAccumulateSales_onNegativeStockDelta() {
+        String eventId = "stock-1";
+        long productId = 2002L;
+        Long delta = -3L; // 재고 3 감소 → 판매량 +3
+        Instant ts = Instant.parse("2025-09-06T02:00:00Z");
+        LocalDate dayKst = LocalDateTime.ofInstant(ts, ZoneId.of("Asia/Seoul")).toLocalDate();
+
+        when(eventHandledJpaRepository.existsById(new EventHandledKey(eventId, "METRICS"))).thenReturn(false);
+
+        service.handleStockAdjusted(eventId, productId, delta, ts);
+
+        verify(productMetricsDailyJpaRepository).upsertDaily(eq(dayKst), eq(productId), eq(0L), eq(3L), eq(ts));
+        verify(eventHandledJpaRepository).save(argThat(e ->
+                e.getEventId() != null
+                        && "METRICS".equals(e.getHandlerName())
+                        && eventId.equals(e.getEventId())
+        ));
+    }
+
+    @Test
+    void shouldNotAccumulateSales_onZeroOrPositiveStockDelta() {
+        String eventId = "stock-2";
+        long productId = 2002L;
+        Instant ts = Instant.parse("2025-09-06T03:00:00Z");
+
+        when(eventHandledJpaRepository.existsById(new EventHandledKey(eventId, "METRICS"))).thenReturn(false);
+
+        // delta = 0
+        service.handleStockAdjusted(eventId, productId, 0L, ts);
+        // delta = +5
+        service.handleStockAdjusted(eventId, productId, 5L, ts);
+
+        verifyNoInteractions(productMetricsDailyJpaRepository); // 판매량 누적 안 함
+        verify(eventHandledJpaRepository, times(2)).save(argThat(e ->
+                e.getEventId() != null &&
+                        "METRICS".equals(e.getHandlerName()) &&
+                        eventId.equals(e.getEventId())
+        ));
+    }
+}

--- a/apps/commerce-streamer/src/test/java/com/loopers/interfaces/consumer/cache/CacheKafkaConsumerTest.java
+++ b/apps/commerce-streamer/src/test/java/com/loopers/interfaces/consumer/cache/CacheKafkaConsumerTest.java
@@ -1,0 +1,91 @@
+package com.loopers.interfaces.consumer.cache;
+
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.loopers.domain.cache.CacheEvictService;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.support.Acknowledgment;
+
+import static org.mockito.Mockito.*;
+
+
+@ExtendWith(MockitoExtension.class)
+public class CacheKafkaConsumerTest {
+
+    @Mock
+    CacheEvictService cache;
+    @Mock
+    Acknowledgment ack;
+
+    @Test
+    public void likeChanged_event_should_evict_cache_and_ack() throws Exception {
+
+        var consumer = new CacheKafkaConsumer(new ObjectMapper(), cache);
+        long productId = 1014L;
+        String json = """
+        {
+          "eventType":"LIKE_CHANGED",
+          "aggregateType":"PRODUCT",
+          "aggregateId":"%d",
+          "updatedAt":"2025-09-05T06:13:26Z",
+          "payload":{"likeCount":1}
+        }
+        """.formatted(productId);
+
+        var rec = new ConsumerRecord<>("catalog-events", 1, 42L, String.valueOf(productId), json);
+
+        consumer.on(rec, ack);
+
+        verify(cache).onLikeChanged(productId);
+        verify(ack).acknowledge();
+        verifyNoMoreInteractions(cache, ack);
+    }
+
+    @Test
+    public void stockAdjusted_event_should_evict_cache_and_ack() throws Exception {
+        var consumer = new CacheKafkaConsumer(new ObjectMapper(), cache);
+        long productId = 2002L;
+        String json = """
+        {
+          "eventType":"STOCK_ADJUSTED",
+          "aggregateType":"PRODUCT",
+          "aggregateId":"%d",
+          "updatedAt":"2025-09-05T06:14:00Z",
+          "payload":{"newStock":7}
+        }
+        """.formatted(productId);
+
+        var rec = new ConsumerRecord<>("catalog-events", 0, 7L, String.valueOf(productId), json);
+
+        consumer.on(rec, ack);
+
+        verify(cache).onStockAdjusted(productId);
+        verify(ack).acknowledge();
+        verifyNoMoreInteractions(cache, ack);
+    }
+
+    @Test
+    public void other_event_should_ack_only() throws Exception {
+        var consumer = new CacheKafkaConsumer(new ObjectMapper(), cache);
+        String json = """
+        {
+          "eventType":"IGNORED",
+          "aggregateType":"PRODUCT",
+          "aggregateId":"9999",
+          "updatedAt":"2025-09-05T06:14:00Z",
+          "payload":{}
+        }
+        """;
+
+        var rec = new ConsumerRecord<>("catalog-events", 2, 1L, "9999", json);
+
+        consumer.on(rec, ack);
+
+        verifyNoInteractions(cache);
+        verify(ack).acknowledge();
+    }
+}

--- a/apps/commerce-streamer/src/test/java/com/loopers/interfaces/consumer/cache/CacheKafkaConsumerTest.java
+++ b/apps/commerce-streamer/src/test/java/com/loopers/interfaces/consumer/cache/CacheKafkaConsumerTest.java
@@ -22,7 +22,7 @@ public class CacheKafkaConsumerTest {
     Acknowledgment ack;
 
     @Test
-    public void likeChanged_event_should_evict_cache_and_ack() throws Exception {
+    public void shouldEvictCacheAndAck_onLikeChanged() throws Exception {
 
         var consumer = new CacheKafkaConsumer(new ObjectMapper(), cache);
         long productId = 1014L;
@@ -46,7 +46,7 @@ public class CacheKafkaConsumerTest {
     }
 
     @Test
-    public void stockAdjusted_event_should_evict_cache_and_ack() throws Exception {
+    public void shouldEvictCacheAndAck_onStockAdjusted() throws Exception {
         var consumer = new CacheKafkaConsumer(new ObjectMapper(), cache);
         long productId = 2002L;
         String json = """
@@ -69,7 +69,7 @@ public class CacheKafkaConsumerTest {
     }
 
     @Test
-    public void other_event_should_ack_only() throws Exception {
+    public void shouldAckOnly_onIrrelevantEvent() throws Exception {
         var consumer = new CacheKafkaConsumer(new ObjectMapper(), cache);
         String json = """
         {

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -3,6 +3,7 @@ version: '3.4'
 networks:
   k6:
   grafana:
+  kafka: {}
 
 services:
   influxdb:
@@ -14,6 +15,38 @@ services:
       - "8086:8086"
     environment:
       - INFLUXDB_DB=k6
+  kafka:
+    image: bitnami/kafka:3.7
+    container_name: kafka
+    ports:
+      - "9092:9092"   # 호스트에서 접속 (spring.kafka.bootstrap-servers=localhost:9092)
+    environment:
+      - KAFKA_ENABLE_KRAFT=yes
+      - KAFKA_CFG_NODE_ID=1
+      - KAFKA_CFG_PROCESS_ROLES=broker,controller
+      - KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER
+      - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093
+      - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://localhost:9092
+      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT
+      - KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=1@localhost:9093
+      - KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=false
+    healthcheck:
+      test: [ "CMD", "bash", "-lc", "kafka-topics.sh --bootstrap-server localhost:9092 --list" ]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+    networks: [ kafka ]
+
+  kafka-ui:
+    image: provectuslabs/kafka-ui:latest
+    container_name: kafka-ui
+    ports:
+      - "8085:8080"   # http://localhost:8085
+    environment:
+      - KAFKA_CLUSTERS_0_NAME=local
+      - KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS=kafka:9092   # 컨테이너 내부 주소
+    depends_on: [ kafka ]
+    networks: [ kafka ]
 
   grafana:
     image: grafana/grafana:9.3.8
@@ -27,3 +60,4 @@ services:
       - GF_AUTH_BASIC_ENABLED=false
     volumes:
       - ./grafana:/etc/grafana/provisioning/
+

--- a/docker/infra-compose.yml
+++ b/docker/infra-compose.yml
@@ -34,6 +34,47 @@ services:
       timeout: 2s
       retries: 10
 
+  kafka:
+    image: bitnami/kafka:3.5.1
+    container_name: kafka
+    ports:
+      - "9092:9092" # 카프카 브로커 PORT
+      - "19092:19092" # 호스트 리스너 얘 떄문인가
+    environment:
+      - KAFKA_CFG_NODE_ID=1 # 브로커 고유 ID
+      - KAFKA_CFG_PROCESS_ROLES=broker,controller # KRaft 모드여서, broker / controller 역할 모두 부여
+      - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,PLAINTEXT_HOST://:19092,CONTROLLER://:9093
+      # 브로커 클라이언트 (PLAINTEXT), 브로커 호스트 (PLAINTEXT) 내부 컨트롤러 (CONTROLLER)
+      - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092,PLAINTEXT_HOST://localhost:19092
+      # 외부 클라이언트 접속 호스트 (localhost:9092), 브로커 접속 호스트 (localhost:19092)
+      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT,CONTROLLER:PLAINTEXT
+      # 각 리스너별 보안 프로토콜 설정
+      - KAFKA_CFG_INTER_BROKER_LISTENER_NAME=PLAINTEXT
+      - KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER # 컨트롤러 담당 리스너 지정
+      - KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=1@kafka:9093 # 컨트롤러 후보 노드 정의 (단일 브로커라 자기 자신만 있음)
+      - KAFKA_CFG_OFFSETS_TOPIC_REPLICATION_FACTOR=1 # consumer offset 복제 갯수 (현재는 1 - 로컬용이라서)
+      - KAFKA_CFG_TRANSACTION_STATE_LOG_REPLICATION_FACTOR=1 # transaction log 토픽 복제 갯수 (현재는 1 - 로컬용이라서)
+      - KAFKA_CFG_TRANSACTION_STATE_LOG_MIN_ISR=1 # In-Sync-Replica 최소 수 (현재는 1 - 로컬용이라서)
+    volumes:
+      - kafka-data:/bitnami/kafka
+    healthcheck:
+      test: ["CMD", "bash", "-c", "kafka-topics.sh --bootstrap-server localhost:9092 --list || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  kafka-ui:
+    image: provectuslabs/kafka-ui:latest
+    container_name: kafka-ui
+    depends_on:
+      kafka:
+        condition: service_healthy
+    ports:
+      - "9090:8080"
+    environment:
+      KAFKA_CLUSTERS_0_NAME: local  # kafka-ui 에서 보이는 클러스터명
+      KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafka:9092 # kafka-ui 가 연겷할 브로커 주소
+
   redis-readonly:
     image: redis:7.0
     container_name: redis-readonly
@@ -63,6 +104,7 @@ volumes:
   mysql-8-data:
   redis_master_data:
   redis_readonly_data:
+  kafka-data:
 
 networks:
   default:

--- a/docker/infra-compose.yml
+++ b/docker/infra-compose.yml
@@ -39,11 +39,10 @@ services:
     container_name: kafka
     ports:
       - "9092:9092" # 카프카 브로커 PORT
-      - "19092:19092" # 호스트 리스너 얘 떄문인가
     environment:
       - KAFKA_CFG_NODE_ID=1 # 브로커 고유 ID
       - KAFKA_CFG_PROCESS_ROLES=broker,controller # KRaft 모드여서, broker / controller 역할 모두 부여
-      - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,PLAINTEXT_HOST://:19092,CONTROLLER://:9093
+      - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,PLAINTEXT_HOST://:9092,CONTROLLER://:9093
       # 브로커 클라이언트 (PLAINTEXT), 브로커 호스트 (PLAINTEXT) 내부 컨트롤러 (CONTROLLER)
       - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092,PLAINTEXT_HOST://localhost:19092
       # 외부 클라이언트 접속 호스트 (localhost:9092), 브로커 접속 호스트 (localhost:19092)

--- a/modules/jpa/src/main/resources/jpa.yml
+++ b/modules/jpa/src/main/resources/jpa.yml
@@ -37,7 +37,7 @@ spring:
   jpa:
     show-sql: true
     hibernate:
-      ddl-auto: validate
+      ddl-auto: update
 
 datasource:
   mysql-jpa:

--- a/modules/kafka/build.gradle.kts
+++ b/modules/kafka/build.gradle.kts
@@ -1,0 +1,14 @@
+plugins {
+    `java-library`
+    `java-test-fixtures`
+}
+
+dependencies {
+    api("org.springframework.kafka:spring-kafka")
+
+    testImplementation("org.springframework.kafka:spring-kafka-test")
+    testImplementation("org.testcontainers:kafka")
+
+    testFixturesImplementation("org.testcontainers:kafka")
+    testFixturesImplementation("org.springframework.kafka:spring-kafka")
+}

--- a/modules/kafka/src/main/java/com/loopers/config/kafka/KafkaConfig.java
+++ b/modules/kafka/src/main/java/com/loopers/config/kafka/KafkaConfig.java
@@ -1,0 +1,81 @@
+package com.loopers.config.kafka;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.listener.ContainerProperties;
+import org.springframework.kafka.support.converter.BatchMessagingMessageConverter;
+import org.springframework.kafka.support.converter.ByteArrayJsonMessageConverter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@EnableKafka
+@Configuration
+public class KafkaConfig {
+
+    public static final String BATCH_LISTENER = "BATCH_LISTENER_DEFAULT";
+
+    private static final int MAX_POLLING_SIZE = 3000;            // read 3000 msg
+    private static final int FETCH_MIN_BYTES = 1024 * 1024;      // 1mb
+    private static final int FETCH_MAX_WAIT_MS = 5 * 1000;       // broker waiting time = 5s
+    private static final int SESSION_TIMEOUT_MS = 60 * 1000;     // session timeout = 1m
+    private static final int HEARTBEAT_INTERVAL_MS = 20 * 1000;  // heartbeat interval = 20s (1/3 of session_timeout)
+    private static final int MAX_POLL_INTERVAL_MS = 2 * 60 * 1000; // max poll interval = 2m
+
+    @Bean
+    public ProducerFactory<Object, Object> producerFactory(KafkaProperties kafkaProperties) {
+        Map<String, Object> props = new HashMap<>(kafkaProperties.buildProducerProperties());
+        return new DefaultKafkaProducerFactory<>(props);
+    }
+
+    @Bean
+    public ConsumerFactory<Object, Object> consumerFactory(KafkaProperties kafkaProperties) {
+        Map<String, Object> props = new HashMap<>(kafkaProperties.buildConsumerProperties());
+        return new DefaultKafkaConsumerFactory<>(props);
+    }
+
+    @Bean
+    public KafkaTemplate<Object, Object> kafkaTemplate(ProducerFactory<Object, Object> producerFactory, ConsumerFactory<Object, Object> consumerFactory) {
+        var template = new KafkaTemplate<>(producerFactory);
+        template.setConsumerFactory(consumerFactory);
+        return template;
+    }
+
+    @Bean
+    public ByteArrayJsonMessageConverter jsonMessageConverter(ObjectMapper objectMapper) {
+        return new ByteArrayJsonMessageConverter(objectMapper);
+    }
+
+    @Bean(name = BATCH_LISTENER)
+    public ConcurrentKafkaListenerContainerFactory<Object, Object> defaultBatchListenerContainerFactory(
+            KafkaProperties kafkaProperties,
+            ByteArrayJsonMessageConverter converter
+    ) {
+        Map<String, Object> consumerConfig = new HashMap<>(kafkaProperties.buildConsumerProperties());
+        consumerConfig.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, MAX_POLLING_SIZE);
+        consumerConfig.put(ConsumerConfig.FETCH_MIN_BYTES_CONFIG, FETCH_MIN_BYTES);
+        consumerConfig.put(ConsumerConfig.FETCH_MAX_WAIT_MS_CONFIG, FETCH_MAX_WAIT_MS);
+        consumerConfig.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, SESSION_TIMEOUT_MS);
+        consumerConfig.put(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, HEARTBEAT_INTERVAL_MS);
+        consumerConfig.put(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, MAX_POLL_INTERVAL_MS);
+
+        ConcurrentKafkaListenerContainerFactory<Object, Object> factory =
+                new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(new DefaultKafkaConsumerFactory<>(consumerConfig));
+        factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.MANUAL);
+        factory.setBatchMessageConverter(new BatchMessagingMessageConverter(converter));
+        factory.setConcurrency(3);
+        factory.setBatchListener(true);
+        return factory;
+    }
+}

--- a/modules/kafka/src/main/resources/kafka.yml
+++ b/modules/kafka/src/main/resources/kafka.yml
@@ -1,0 +1,44 @@
+spring:
+  kafka:
+    bootstrap-servers: ${BOOTSTRAP_SERVERS}
+    client-id: ${spring.application.name}
+    properties:
+      spring.json.add.type.headers: false # json serialize off
+      request.timeout.ms: 20000
+      retry.backoff.ms: 500
+      auto:
+        create.topics.enable: false
+        register.schemas: false
+        offset.reset: latest
+      use.latest.version: true
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      retries: 3
+    consumer:
+      group-id: loopers-default-consumer
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-serializer: org.apache.kafka.common.serialization.ByteArrayDeserializer
+      properties:
+        enable-auto-commit: false
+    listener:
+      ack-mode: manual
+
+---
+spring.config.activate.on-profile: local, test
+
+spring:
+  kafka:
+    bootstrap-servers: localhost:19092
+    admin:
+      properties:
+        bootstrap.servers: kafka:9092
+
+---
+spring.config.activate.on-profile: dev
+
+---
+spring.config.activate.on-profile: qa
+
+---
+spring.config.activate.on-profile: prd

--- a/modules/kafka/src/main/resources/kafka.yml
+++ b/modules/kafka/src/main/resources/kafka.yml
@@ -14,7 +14,10 @@ spring:
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      acks: all
       retries: 3
+      properties:
+        enable.idempotence: true
     consumer:
       group-id: loopers-default-consumer
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
@@ -23,13 +26,16 @@ spring:
         enable-auto-commit: false
     listener:
       ack-mode: manual
-
+logging:
+  level:
+    org.springframework.kafka: INFO
+    com.loopers: DEBUG
 ---
 spring.config.activate.on-profile: local, test
 
 spring:
   kafka:
-    bootstrap-servers: localhost:19092
+    bootstrap-servers: localhost:9092
     admin:
       properties:
         bootstrap.servers: kafka:9092

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -5,6 +5,7 @@ include(
     ":apps:pg-simulator",
     ":modules:jpa",
     ":modules:redis",
+    ":modules:kafka",
     ":supports:jackson",
     ":supports:logging",
     ":supports:monitoring",

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,6 +3,7 @@ rootProject.name = "jinnie-commerce"
 include(
     ":apps:commerce-api",
     ":apps:pg-simulator",
+    ":apps:commerce-streamer",
     ":modules:jpa",
     ":modules:redis",
     ":modules:kafka",


### PR DESCRIPTION
## 📌 Summary
- Kafka Producer & Consumer
- At Most Once / At Least Once / Exactly Once
- Idempotency & 멱등 처리
- Dead Letter Queue (DLQ)

## 💬 Review Points
commerce-api → Kafka → commerce-streamer 구조를 설정하여 두 개의 애플리케이션을 실행 해
API 호출 → Consumer의 소비 상태 확인 → Producer의 발행 확인 → 이벤트 로그 및 집계 DB 적재 확인 까지 테스트 해보았습니다.
일별 집계, 캐시도 구현 예정입니다...

## ✅ Checklist
### 🎾 Producer

- [ ]  도메인(애플리케이션) 이벤트 설계
- [ ]  Producer 앱에서 도메인 이벤트 발행 (catalog-events, order-events, 등)
- [ ]  **PartitionKey** 기반의 이벤트 순서 보장
- [ ]  메세지 발행이 실패했을 경우에 대해 고민해보기

### ⚾ Consumer

- [ ]  Consumer 앱에서 3종 처리 (Audit Log / Cache Evict / Metrics 집계)
- [ ]  `event_handled` 테이블을 통한 멱등 처리 구현
- [ ]  재고 소진 시 상품 캐시 삭제
- [ ]  중복 메세지 재전송 테스트 → 최종 결과가 한 번만 반영되는지 확인
## 📎 References
<!--
  (Optional: 참고 자료가 없는 작업 - 단순 버그 픽스 등 의 경우엔 해당 란을 제거해주세요 !)
  리뷰어가 참고할 수 있는 추가적인 정보나 문서, 링크 등을 작성해주세요.
  예시:
  - 관련 문서 링크
  - 관련 정책 링크
-->