### PR TITLE
[volume-9] Ranking System - Redis ZSET

### DIFF
--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductFacade.java
@@ -1,12 +1,15 @@
 package com.loopers.application.product;
 
+import com.loopers.application.ranking.RankingFacade;
 import com.loopers.domain.brand.BrandService;
 import com.loopers.domain.like.LikeService;
 import com.loopers.domain.product.ProductEntity;
 import com.loopers.domain.product.ProductInfo;
 import com.loopers.domain.product.ProductService;
 import com.loopers.domain.product.ProductSortType;
+import com.loopers.domain.product.event.ProductViewed;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
@@ -20,6 +23,8 @@ public class ProductFacade {
     private final LikeService likeService;
     private final BrandService brandService;
     private final ProductQueryRepository productQueryRepository;
+    private final RankingFacade rankingFacade;
+    private final ApplicationEventPublisher publisher;
 
     /**
      * 단건 조회 - 브랜드, 좋아요 수 포함하여 반환
@@ -29,7 +34,16 @@ public class ProductFacade {
         String brandName = brandService.getBrandName(productInfo.brandId());
         long likeCount = likeService.countByProductId(productInfo.id());
 
-        return ProductResult.of(productInfo, brandName, likeCount);
+        // 오늘의 랭킹(없으면 null)
+        var rankOpt = rankingFacade.getTodayRankOf(productId);
+        Long todayRank = null; Double todayScore = null;
+        if (rankOpt.isPresent()) {
+            todayRank = rankOpt.get().rank();
+            todayScore = rankOpt.get().score();
+        }
+        publisher.publishEvent(new ProductViewed(productId, /*viewerId*/ null));
+
+        return ProductResult.ofWithRank(productInfo, brandName, likeCount, todayRank, todayScore);
     }
 
     /**

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductResult.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductResult.java
@@ -9,7 +9,9 @@ public record ProductResult(
         Long stock,
         Long brandId,
         String brandName,
-        Long likeCount
+        Long likeCount,
+        Long todayRank,
+        Double todayScore
 ) {
     public static ProductResult of(ProductInfo info, String brandName, Long likeCount) {
         return new ProductResult(
@@ -19,7 +21,23 @@ public record ProductResult(
                 info.stock(),
                 info.brandId(),
                 brandName,
-                likeCount
+                likeCount,
+                null,
+                null
         );
     }
+    public static ProductResult ofWithRank(ProductInfo info, String brandName, Long likeCount, Long todayRank, Double todayScore) {
+        return new ProductResult(
+                info.id(),
+                info.name(),
+                info.price(),
+                info.stock(),
+                info.brandId(),
+                brandName,
+                likeCount,
+                todayRank,
+                todayScore
+        );
+    }
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingFacade.java
@@ -1,0 +1,48 @@
+package com.loopers.application.ranking;
+
+import com.loopers.domain.ranking.RankingItem;
+import com.loopers.domain.ranking.RankingPage;
+import com.loopers.domain.ranking.RankingPolicy;
+import com.loopers.domain.ranking.RankingRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class RankingFacade {
+
+    private final RankingRepository rankingRepository;
+
+    public RankingPage getRankingPage(LocalDate date, int page, int size) {
+        String key = RankingPolicy.all(date);
+        long total = rankingRepository.size(key);
+        if (total == 0) return RankingPage.empty(page, size);
+
+        long start = Math.max(0, (long) (page - 1) * size);
+        long end = start + size - 1;
+
+        var rows = rankingRepository.reverseRangeWithScores(key, start, end);
+        if (rows.isEmpty()) return RankingPage.empty(page, size);
+
+        List<RankingItem> items = new ArrayList<>(rows.size());
+        for (int i = 0; i < rows.size(); i++) {
+            var ms = rows.get(i);
+            long rank = start + i + 1;
+            items.add(new RankingItem(ms.productId(), ms.score(), rank));
+        }
+        return new RankingPage(items, page, size, total);
+    }
+
+    public Optional<RankingItem> getTodayRankOf(long productId) {
+        String key = RankingPolicy.all(LocalDate.now(RankingPolicy.ZONE));
+        var rankOpt = rankingRepository.reverseRank(key, productId);
+        if (rankOpt.isEmpty()) return Optional.empty();
+        var scoreOpt = rankingRepository.score(key, productId);
+        return Optional.of(new RankingItem(productId, scoreOpt.orElse(0.0), rankOpt.get() + 1));
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingFacade.java
@@ -39,7 +39,7 @@ public class RankingFacade {
     }
 
     public Optional<RankingItem> getTodayRankOf(long productId) {
-        String key = RankingPolicy.all(LocalDate.now(RankingPolicy.ZONE));
+        String key = RankingPolicy.all(LocalDate.now());
         var rankOpt = rankingRepository.reverseRank(key, productId);
         if (rankOpt.isEmpty()) return Optional.empty();
         var scoreOpt = rankingRepository.score(key, productId);

--- a/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingFacade.java
@@ -1,22 +1,23 @@
 package com.loopers.application.ranking;
 
-import com.loopers.domain.ranking.RankingItem;
-import com.loopers.domain.ranking.RankingPage;
-import com.loopers.domain.ranking.RankingPolicy;
-import com.loopers.domain.ranking.RankingRepository;
+import com.loopers.domain.brand.BrandService;
+import com.loopers.domain.product.ProductEntity;
+import com.loopers.domain.product.ProductRepository;
+import com.loopers.domain.ranking.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class RankingFacade {
 
     private final RankingRepository rankingRepository;
+    private final ProductRepository productRepository;
+    private final BrandService brandService;
 
     public RankingPage getRankingPage(LocalDate date, int page, int size) {
         String key = RankingPolicy.all(date);
@@ -36,6 +37,53 @@ public class RankingFacade {
             items.add(new RankingItem(ms.productId(), ms.score(), rank));
         }
         return new RankingPage(items, page, size, total);
+    }
+
+    public RankingProductPage getRankingPageWithProducts(LocalDate date, int page, int size) {
+        String key = RankingPolicy.all(date);
+        long total = rankingRepository.size(key);
+        if (total == 0) return RankingProductPage.empty(page, size);
+
+        long start = Math.max(0, (long) (page - 1) * size);
+        long end   = start + size - 1;
+
+        var rows = rankingRepository.reverseRangeWithScores(key, start, end);
+        if (rows.isEmpty()) return RankingProductPage.empty(page, size);
+
+        // 1) 필요한 상품 id 수집
+        List<Long> ids = rows.stream().map(r -> r.productId()).toList();
+        Set<Long> idSet = new HashSet<>(ids);
+
+        // 2) 배치 조회
+        List<ProductEntity> products = productRepository.findAllById(idSet);
+        Map<Long, ProductEntity> byId = products.stream()
+                .collect(Collectors.toMap(ProductEntity::getId, p -> p));
+
+        // 3) 브랜드명 조회(간단하게 per-item 호출; 필요하면 배치화)
+        List<RankingProductItem> items = new ArrayList<>(rows.size());
+        for (int i = 0; i < rows.size(); i++) {
+            var ms   = rows.get(i);
+            long rank = start + i + 1;
+
+            ProductEntity p = byId.get(ms.productId());
+            if (p == null) {
+                // 상품이 삭제/비활성화된 경우 스킵하거나 placeholder 처리
+                continue;
+            }
+            String brandName = brandService.getBrandName(p.getBrandId());
+
+            items.add(new RankingProductItem(
+                    p.getId(),
+                    rank,
+                    ms.score(),
+                    p.getName(),
+                    p.getPrice(),
+                    p.getStock(),
+                    p.getBrandId(),
+                    brandName
+            ));
+        }
+        return new RankingProductPage(items, page, size, total);
     }
 
     public Optional<RankingItem> getTodayRankOf(long productId) {

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeService.java
@@ -18,7 +18,6 @@ import java.util.List;
 public class LikeService {
 
     private final LikeRepository likeRepository;
-    private final ProductJpaRepository productJpaRepository;
     private final ApplicationEventPublisher publisher;
 
 

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeService.java
@@ -1,6 +1,6 @@
 package com.loopers.domain.like;
 
-import com.loopers.domain.event.LikeCountUpdated;
+import com.loopers.domain.like.event.LikeChangedEvent;
 import com.loopers.infrastructure.product.ProductJpaRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -40,14 +40,7 @@ public class LikeService {
         }
 
         if (changed) {
-            long likeCount = likeRepository.countByProductId(productId);
-
-            log.info("[LIKE] publish LikeCountUpdated productId={} likeCount={}", productId, likeCount); // ★
-            productJpaRepository.findById(productId).ifPresent(p -> {
-                p.setLikeCount(likeCount);
-                productJpaRepository.save(p);
-            });
-            publisher.publishEvent(LikeCountUpdated.of(productId, likeCount));
+            publisher.publishEvent(LikeChangedEvent.of(productId, +1));
         }
         return LikeInfo.liked(userId, productId);
     }
@@ -59,15 +52,7 @@ public class LikeService {
 
         int removed = likeRepository.deleteByUserIdAndProductId(userId, productId);
         if (removed == 1) {
-            long likeCount = likeRepository.countByProductId(productId);
-
-            // (선택) ProductEntity.likeCount 동기화
-            productJpaRepository.findById(productId).ifPresent(p -> {
-                p.setLikeCount(likeCount);
-                productJpaRepository.save(p);
-            });
-
-            publisher.publishEvent(LikeCountUpdated.of(productId, likeCount));
+            publisher.publishEvent(LikeChangedEvent.of(productId, -1));
         }
         return LikeInfo.unliked(userId, productId);
     }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/event/LikeChangedEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/event/LikeChangedEvent.java
@@ -1,7 +1,19 @@
 package com.loopers.domain.like.event;
 
+public record LikeChangedEvent(
+        Long userId,
+        Long productId,
+        int  delta // +1 or -1
+) {
+    public static LikeChangedEvent liked(Long userId, Long productId) {
+        return new LikeChangedEvent(userId, productId, +1);
+    }
 
-public record LikeChangedEvent(Long userId, Long productId, int delta) {
-    public static LikeChangedEvent liked(Long userId, Long productId) {return new LikeChangedEvent(userId, productId, +1);}
-    public static LikeChangedEvent unliked(Long userId, Long productId) {return new LikeChangedEvent(userId, productId, -1);}
+    public static LikeChangedEvent unliked(Long userId, Long productId) {
+        return new LikeChangedEvent(userId, productId, -1);
+    }
+
+    public static LikeChangedEvent of(Long productId, int delta) {
+        return new LikeChangedEvent(null, productId, delta > 0 ? +1 : -1);
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/event/OrderPlacedEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/event/OrderPlacedEvent.java
@@ -1,0 +1,10 @@
+package com.loopers.domain.order.event;
+
+import java.util.List;
+
+public record OrderPlacedEvent(
+        String orderId,
+        List<Item> items
+) {
+    public record Item(long productId, long price, long amount) {}
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/event/ProductLiked.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/event/ProductLiked.java
@@ -1,0 +1,3 @@
+package com.loopers.domain.product.event;
+
+public record ProductLiked(long productId, Long userId, int delta) {}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/event/ProductViewed.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/event/ProductViewed.java
@@ -1,0 +1,6 @@
+package com.loopers.domain.product.event;
+
+public record ProductViewed (
+    long productId,
+    Long viewerId
+){}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingItem.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingItem.java
@@ -1,0 +1,7 @@
+package com.loopers.domain.ranking;
+
+public record RankingItem(
+        long productId,
+        Double score,
+        Long rank
+) {}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingPage.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingPage.java
@@ -1,0 +1,14 @@
+package com.loopers.domain.ranking;
+
+import java.util.List;
+
+public record RankingPage(
+        List<RankingItem> items,
+        int page,
+        int size,
+        long total
+) {
+    public static RankingPage empty(int page, int size) {
+        return new RankingPage(List.of(), page, size, 0L);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingPolicy.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingPolicy.java
@@ -1,19 +1,17 @@
 package com.loopers.domain.ranking;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
-import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 
 public class RankingPolicy {
 
-    public static final ZoneId ZONE = ZoneId.of("Asia/Seoul");
     public static final DateTimeFormatter FMT = DateTimeFormatter.BASIC_ISO_DATE;
 
     public static String all(LocalDate d) { return "ranking:all:" + d.format(FMT); }
 
-    public static Instant expireAt(LocalDate d) {
-        return d.plusDays(2).atStartOfDay(ZONE).toInstant();
+    public static Instant expireAt() {
+        return Instant.now().plus(Duration.ofDays(2));
     }
-
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingPolicy.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingPolicy.java
@@ -1,0 +1,19 @@
+package com.loopers.domain.ranking;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+
+public class RankingPolicy {
+
+    public static final ZoneId ZONE = ZoneId.of("Asia/Seoul");
+    public static final DateTimeFormatter FMT = DateTimeFormatter.BASIC_ISO_DATE;
+
+    public static String all(LocalDate d) { return "ranking:all:" + d.format(FMT); }
+
+    public static Instant expireAt(LocalDate d) {
+        return d.plusDays(2).atStartOfDay(ZONE).toInstant();
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingProductItem.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingProductItem.java
@@ -1,0 +1,12 @@
+package com.loopers.domain.ranking;
+
+public record RankingProductItem(
+        Long productId,
+        Long rank,
+        Double score,
+        String name,
+        Long price,
+        Long stock,
+        Long brandId,
+        String brandName
+) {}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingProductPage.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingProductPage.java
@@ -1,0 +1,14 @@
+package com.loopers.domain.ranking;
+
+import java.util.List;
+
+public record RankingProductPage(
+        List<RankingProductItem> items,
+        int page,
+        int size,
+        long total
+) {
+    public static RankingProductPage empty(int page, int size) {
+        return new RankingProductPage(List.of(), page, size, 0L);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingRepository.java
@@ -1,0 +1,16 @@
+package com.loopers.domain.ranking;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface RankingRepository {
+    long size(String key);
+
+    List<MemberScore> reverseRangeWithScores(String key, long start, long end);
+
+    Optional<Long> reverseRank(String key, long productId);
+
+    Optional<Double> score(String key, long productId);
+
+    record MemberScore(long productId, double score) {}
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/kafka/AfterCommitKafkaBridge.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/kafka/AfterCommitKafkaBridge.java
@@ -1,8 +1,9 @@
 package com.loopers.infrastructure.kafka;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.loopers.domain.event.LikeCountUpdated;
+import com.loopers.domain.like.event.LikeChangedEvent;
 import com.loopers.domain.order.event.OrderCreatedEvent;
+import com.loopers.domain.product.event.ProductLiked;
 import com.loopers.domain.product.event.ProductViewed;
 import com.loopers.domain.product.event.StockAdjusted;
 import lombok.RequiredArgsConstructor;
@@ -31,21 +32,13 @@ public class AfterCommitKafkaBridge {
     private final ObjectMapper om = new ObjectMapper();
 
     @TransactionalEventListener(phase = AFTER_COMMIT)
-    public void on(LikeCountUpdated e) {
+    public void on(LikeChangedEvent e) {
         try {
             String key = e.productId().toString();
-            String json = om.writeValueAsString(Map.of(
-                    "eventId",     e.eventId(),
-                    "eventType",   "LIKE_CHANGED",
-                    "aggregateType","PRODUCT",
-                    "aggregateId", key,
-                    "updatedAt",   e.updatedAt().toString(),
-                    "producerApp", "commerce-api",
-                    "payload",     Map.of("likeCount", e.likeCount())
-            ));
-
-            kafka.send(TOPIC, key, json).get();
-
+            String json = om.writeValueAsString(new ProductLiked(e.productId(), null, e.delta()));
+            ProducerRecord<Object, Object> rec = new ProducerRecord<>(TOPIC, key, json);
+            rec.headers().add("event-type", "LIKE".getBytes(StandardCharsets.UTF_8));
+            kafka.send(rec);
         } catch (Exception ex) {
             throw new RuntimeException("Kafka publish failed", ex);
         }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/kafka/AfterCommitKafkaBridge.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/kafka/AfterCommitKafkaBridge.java
@@ -3,9 +3,11 @@ package com.loopers.infrastructure.kafka;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.loopers.domain.like.event.LikeChangedEvent;
 import com.loopers.domain.order.event.OrderCreatedEvent;
+import com.loopers.domain.order.event.OrderPlacedEvent;
 import com.loopers.domain.product.event.ProductLiked;
 import com.loopers.domain.product.event.ProductViewed;
 import com.loopers.domain.product.event.StockAdjusted;
+import com.loopers.infrastructure.order.OrderJpaRepository;
 import lombok.RequiredArgsConstructor;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.springframework.context.event.EventListener;
@@ -14,10 +16,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionalEventListener;
 
 import java.nio.charset.StandardCharsets;
-import java.time.Instant;
-import java.util.HashMap;
 import java.util.Map;
-import java.util.UUID;
 
 import static org.springframework.transaction.event.TransactionPhase.AFTER_COMMIT;
 
@@ -30,6 +29,7 @@ public class AfterCommitKafkaBridge {
 
     private final KafkaTemplate<Object, Object> kafka;
     private final ObjectMapper om = new ObjectMapper();
+    private final OrderJpaRepository orderJpaRepository;
 
     @TransactionalEventListener(phase = AFTER_COMMIT)
     public void on(LikeChangedEvent e) {
@@ -66,27 +66,24 @@ public class AfterCommitKafkaBridge {
     @TransactionalEventListener(phase = AFTER_COMMIT)
     public void on(OrderCreatedEvent e) {
         try {
-            String key = e.orderId().toString();
+            var order = orderJpaRepository.findByIdWithItems(e.orderId())
+                    .orElseThrow(() -> new IllegalStateException("order not found: " + e.orderId()));
 
-            // payload는 null 가능성이 있어 Map.of 대신 가변 Map 사용
-            Map<String, Object> payload = new HashMap<>();
-            payload.put("userId",      e.userId());
-            payload.put("totalAmount", e.totalAmount());
-            payload.put("couponId",    e.couponId());
-            payload.put("method",      e.method() != null ? e.method().name() : null);
-            payload.put("cardType",    e.cardType());
+            var items = order.getOrderItems().stream()
+                    .map(it -> new OrderPlacedEvent.Item(
+                            it.getProductId(),
+                            it.getPrice(),
+                            it.getQuantity()
+                    ))
+                    .toList();
 
-            String json = om.writeValueAsString(Map.of(
-                    "eventId",       UUID.randomUUID().toString(),
-                    "eventType",     "ORDER_CREATED",
-                    "aggregateType", "ORDER",
-                    "aggregateId",   key,
-                    "updatedAt",     Instant.now().toString(),
-                    "producerApp",   "commerce-api",
-                    "payload",       payload
-            ));
+            String json = om.writeValueAsString(new OrderPlacedEvent(String.valueOf(e.orderId()), items));
 
-            kafka.send(ORDER_TOPIC, key, json).get();
+            ProducerRecord<Object, Object> rec =
+                    new ProducerRecord<>(ORDER_TOPIC, String.valueOf(e.orderId()), json);
+            rec.headers().add("event-type", "ORDER".getBytes(java.nio.charset.StandardCharsets.UTF_8));
+
+            kafka.send(rec);
         } catch (Exception ex) {
             throw new RuntimeException("Kafka publish failed", ex);
         }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/kafka/AfterCommitKafkaBridge.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/kafka/AfterCommitKafkaBridge.java
@@ -3,12 +3,16 @@ package com.loopers.infrastructure.kafka;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.loopers.domain.event.LikeCountUpdated;
 import com.loopers.domain.order.event.OrderCreatedEvent;
+import com.loopers.domain.product.event.ProductViewed;
 import com.loopers.domain.product.event.StockAdjusted;
 import lombok.RequiredArgsConstructor;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.springframework.context.event.EventListener;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionalEventListener;
 
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
@@ -90,6 +94,21 @@ public class AfterCommitKafkaBridge {
             ));
 
             kafka.send(ORDER_TOPIC, key, json).get();
+        } catch (Exception ex) {
+            throw new RuntimeException("Kafka publish failed", ex);
+        }
+    }
+
+    @EventListener
+    public void on(ProductViewed event) {
+        try {
+            Object key = String.valueOf(event.productId());
+            Object payload = om.writeValueAsString(event);
+
+            ProducerRecord<Object, Object> rec = new ProducerRecord<>(TOPIC, key, payload);
+            rec.headers().add("event-type", "VIEW".getBytes(StandardCharsets.UTF_8));
+
+            kafka.send(rec);
         } catch (Exception ex) {
             throw new RuntimeException("Kafka publish failed", ex);
         }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/order/OrderJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/order/OrderJpaRepository.java
@@ -2,10 +2,15 @@ package com.loopers.infrastructure.order;
 
 import com.loopers.domain.order.OrderEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface OrderJpaRepository extends JpaRepository<OrderEntity, Long> {
     List<OrderEntity> findByUserId(@Param("userId") Long userId);
+
+    @Query("select o from OrderEntity o left join fetch o.orderItems where o.id = :id")
+    Optional<OrderEntity> findByIdWithItems(@Param("id") Long id);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/ranking/RankingRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/ranking/RankingRepositoryImpl.java
@@ -1,0 +1,52 @@
+package com.loopers.infrastructure.ranking;
+
+import com.loopers.domain.ranking.RankingRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.stereotype.Repository;
+
+import java.util.*;
+
+@Repository
+@RequiredArgsConstructor
+public class RankingRepositoryImpl implements RankingRepository {
+
+    private final StringRedisTemplate redis;
+
+    @Override public long size(String key) {
+        Long v = redis.opsForZSet().size(key);
+        return v == null ? 0L : v;
+    }
+
+    @Override
+    public List<MemberScore> reverseRangeWithScores(String key, long start, long end) {
+        Set<ZSetOperations.TypedTuple<String>> tuples =
+                redis.opsForZSet().reverseRangeWithScores(key, start, end);
+        if (tuples == null || tuples.isEmpty()) return List.of();
+
+        List<MemberScore> list = new ArrayList<>(tuples.size());
+        for (var t : tuples) {
+            String member = t.getValue();
+            if (member == null || t.getScore() == null) continue;
+            try {
+                long productId = Long.parseLong(member);
+                list.add(new MemberScore(productId, t.getScore()));
+            } catch (NumberFormatException ignore) {
+            }
+        }
+        return list;
+    }
+
+    @Override
+    public Optional<Long> reverseRank(String key, long productId) {
+        Long rank = redis.opsForZSet().reverseRank(key, String.valueOf(productId));
+        return Optional.ofNullable(rank);
+    }
+
+    @Override
+    public Optional<Double> score(String key, long productId) {
+        Double s = redis.opsForZSet().score(key, String.valueOf(productId));
+        return Optional.ofNullable(s);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/ranking/RedisRankingRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/ranking/RedisRankingRepositoryImpl.java
@@ -10,7 +10,7 @@ import java.util.*;
 
 @Repository
 @RequiredArgsConstructor
-public class RankingRepositoryImpl implements RankingRepository {
+public class RedisRankingRepositoryImpl implements RankingRepository {
 
     private final StringRedisTemplate redis;
 

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingItemResponse.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingItemResponse.java
@@ -1,0 +1,27 @@
+package com.loopers.interfaces.api.ranking;
+
+import com.loopers.domain.ranking.RankingProductItem;
+
+public record RankingItemResponse(
+        Long productId,
+        Long rank,
+        Double score,
+        String name,
+        Long price,
+        Long stock,
+        Long brandId,
+        String brandName
+) {
+    public static RankingItemResponse from(RankingProductItem productItem) {
+        return new RankingItemResponse(
+                productItem.productId(),
+                productItem.rank(),
+                productItem.score(),
+                productItem.name(),
+                productItem.price(),
+                productItem.stock(),
+                productItem.brandId(),
+                productItem.brandName()
+        );
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingPageResponse.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingPageResponse.java
@@ -1,0 +1,10 @@
+package com.loopers.interfaces.api.ranking;
+
+import java.util.List;
+
+public record RankingPageResponse(
+        int page,
+        int size,
+        long total,
+        List<RankingItemResponse> items
+) {}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1ApiSpec.java
@@ -1,0 +1,15 @@
+package com.loopers.interfaces.api.ranking;
+
+import com.loopers.domain.ranking.RankingPage;
+import com.loopers.interfaces.api.ApiResponse;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@RequestMapping("/api/v1/rankings")
+public interface RankingV1ApiSpec {
+    @GetMapping
+    ApiResponse<RankingPage> page(@RequestParam String date,
+                                  @RequestParam(defaultValue = "20") int size,
+                                  @RequestParam(defaultValue = "1") int page);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1ApiSpec.java
@@ -1,15 +1,16 @@
 package com.loopers.interfaces.api.ranking;
 
-import com.loopers.domain.ranking.RankingPage;
 import com.loopers.interfaces.api.ApiResponse;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import java.time.LocalDate;
+
 @RequestMapping("/api/v1/rankings")
 public interface RankingV1ApiSpec {
     @GetMapping
-    ApiResponse<RankingPage> page(@RequestParam String date,
+    ApiResponse<RankingPageResponse> page(@RequestParam LocalDate date,
                                   @RequestParam(defaultValue = "20") int size,
                                   @RequestParam(defaultValue = "1") int page);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1Controller.java
@@ -1,0 +1,23 @@
+package com.loopers.interfaces.api.ranking;
+
+import com.loopers.application.ranking.RankingFacade;
+import com.loopers.domain.ranking.RankingPage;
+import com.loopers.interfaces.api.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+@RestController
+@RequiredArgsConstructor
+public class RankingV1Controller implements RankingV1ApiSpec {
+
+    private final RankingFacade facade;
+
+    @Override
+    public ApiResponse<RankingPage> page(String date, int size, int page) {
+        LocalDate d = LocalDate.parse(date, DateTimeFormatter.BASIC_ISO_DATE); // yyyyMMdd
+        return ApiResponse.success(facade.getRankingPage(d, page, size));
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1Controller.java
@@ -1,23 +1,35 @@
 package com.loopers.interfaces.api.ranking;
 
 import com.loopers.application.ranking.RankingFacade;
-import com.loopers.domain.ranking.RankingPage;
+import com.loopers.domain.ranking.RankingProductPage;
 import com.loopers.interfaces.api.ApiResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
 
 @RestController
 @RequiredArgsConstructor
 public class RankingV1Controller implements RankingV1ApiSpec {
 
-    private final RankingFacade facade;
+    private final RankingFacade rankingFacade;
 
     @Override
-    public ApiResponse<RankingPage> page(String date, int size, int page) {
-        LocalDate d = LocalDate.parse(date, DateTimeFormatter.BASIC_ISO_DATE); // yyyyMMdd
-        return ApiResponse.success(facade.getRankingPage(d, page, size));
+    public ApiResponse<RankingPageResponse> page(
+            @RequestParam @DateTimeFormat(pattern = "yyyyMMdd") LocalDate date,
+            @RequestParam(defaultValue = "20") int size,
+            @RequestParam(defaultValue = "1") int page
+    ) {
+        RankingProductPage p = rankingFacade.getRankingPageWithProducts(date, page, size);
+
+        var resp = new RankingPageResponse(
+                p.page(),
+                p.size(),
+                p.total(),
+                p.items().stream().map(RankingItemResponse::from).toList()
+        );
+        return ApiResponse.success(resp);
     }
 }

--- a/apps/commerce-api/src/test/java/com/loopers/application/product/ProductFacadeIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/product/ProductFacadeIntegrationTest.java
@@ -1,25 +1,52 @@
 package com.loopers.application.product;
 
+import com.loopers.application.ranking.RankingFacade;
+import com.loopers.config.redis.RedisConfig;
 import com.loopers.domain.brand.BrandEntity;
 import com.loopers.domain.brand.BrandRepository;
 import com.loopers.domain.like.LikeEntity;
 import com.loopers.domain.like.LikeRepository;
 import com.loopers.domain.product.*;
+import com.loopers.domain.product.event.ProductViewed;
+import com.loopers.domain.ranking.RankingItem;
+import com.loopers.infrastructure.kafka.AfterCommitKafkaBridge;
 import com.loopers.utils.DatabaseCleanUp;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.support.NoOpCacheManager;
+import org.springframework.context.annotation.Bean;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.event.ApplicationEvents;
+import org.springframework.test.context.event.RecordApplicationEvents;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
 
 @DisplayName("ProductFacade 통합 테스트")
-@SpringBootTest
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.NONE,
+        properties = {
+                "spring.autoconfigure.exclude=" +
+                        "org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration," +
+                        "org.springframework.boot.autoconfigure.data.redis.RedisRepositoriesAutoConfiguration," +
+                        "org.springframework.boot.autoconfigure.data.redis.RedisReactiveAutoConfiguration",
+                "spring.cache.type=NONE",
+                "spring.main.allow-bean-definition-overriding=true"
+        }
+)
+@RecordApplicationEvents
 class ProductFacadeIntegrationTest {
 
     @Autowired
@@ -33,6 +60,25 @@ class ProductFacadeIntegrationTest {
 
     @Autowired
     private LikeRepository likeRepository;
+
+    @MockitoBean private RankingFacade rankingFacade;
+
+    @MockitoBean private AfterCommitKafkaBridge bridge;
+
+    @MockitoBean private KafkaTemplate<Object, Object> kafka;
+
+    @MockitoBean private StringRedisTemplate stringRedisTemplate;
+
+    @Autowired
+    private ApplicationEvents events;
+
+    @TestConfiguration
+    static class NoRedisCacheConfig {
+        @Bean(name = RedisConfig.CACHE_MANAGER_MASTER)
+        public CacheManager masterNoOpCacheManager() {
+            return new NoOpCacheManager();
+        }
+    }
 
     @Autowired
     private DatabaseCleanUp databaseCleanUp;
@@ -117,5 +163,49 @@ class ProductFacadeIntegrationTest {
         // assert
         assertThat(results).hasSize(2);
         assertThat(results.get(0).likeCount()).isGreaterThanOrEqualTo(results.get(1).likeCount());
+    }
+
+    @Test
+    @DisplayName("랭킹이 있으면 todayRank/todayScore를 세팅하고 조회 이벤트를 발행한다")
+    void getProduct_todayRank_todayScore() {
+        // arrange
+        var brand = brandRepository.save(BrandEntity.of("Apple", "애플"));
+        var product = productRepository.save(ProductEntity.of("아이폰", 1_200_000L, 15L, brand.getId()));
+        likeRepository.save(LikeEntity.of(1L, product.getId()));
+        likeRepository.save(LikeEntity.of(2L, product.getId()));
+
+        when(rankingFacade.getTodayRankOf(product.getId()))
+                .thenReturn(Optional.of(new RankingItem(product.getId(), 9.9, 3L)));
+
+        // act
+        ProductResult r = productFacade.getProduct(product.getId());
+
+        // assert
+        assertThat(r.name()).isEqualTo("아이폰");
+        assertThat(r.brandName()).isEqualTo("Apple");
+        assertThat(r.likeCount()).isEqualTo(2L);
+        assertThat(r.todayRank()).isEqualTo(3L);
+        assertThat(r.todayScore()).isEqualTo(9.9);
+
+        // assert – 조회 이벤트 발행 확인
+        long viewEvents = events.stream(ProductViewed.class).count();
+        assertThat(viewEvents).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("랭킹이 없으면 todayRank/todayScore는 null이고 조회 이벤트는 발행된다")
+    void getProduct_todayRank_todayScore_null() {
+        var brand = brandRepository.save(BrandEntity.of("Brand", "설명"));
+        var product = productRepository.save(ProductEntity.of("상품", 10_000L, 5L, brand.getId()));
+
+        when(rankingFacade.getTodayRankOf(product.getId())).thenReturn(Optional.empty());
+
+        ProductResult r = productFacade.getProduct(product.getId());
+
+        assertThat(r.todayRank()).isNull();
+        assertThat(r.todayScore()).isNull();
+
+        long viewEvents = events.stream(ProductViewed.class).count();
+        assertThat(viewEvents).isEqualTo(1L);
     }
 }

--- a/apps/commerce-api/src/test/java/com/loopers/application/ranking/RankingFacadeIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/ranking/RankingFacadeIntegrationTest.java
@@ -1,0 +1,109 @@
+package com.loopers.application.ranking;
+
+import com.loopers.domain.ranking.RankingItem;
+import com.loopers.domain.ranking.RankingPage;
+import com.loopers.domain.ranking.RankingRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class RankingFacadeIntegrationTest {
+    @Mock RankingRepository rankingRepository;
+
+    @Test
+    @DisplayName("총 개수가 0이면 빈 페이지를 반환한다")
+    void getRankingPage_empty_when_total_zero() {
+        RankingFacade sut = new RankingFacade(rankingRepository);
+        when(rankingRepository.size(anyString())).thenReturn(0L);
+
+        RankingPage page = sut.getRankingPage(LocalDate.of(2025, 9, 11), 1, 10);
+
+        assertThat(page.total()).isEqualTo(0);
+        assertThat(page.items()).isEmpty();
+        assertThat(page.page()).isEqualTo(1);
+        assertThat(page.size()).isEqualTo(10);
+
+        verify(rankingRepository, times(1)).size(anyString());
+        verify(rankingRepository, never()).reverseRangeWithScores(anyString(), anyLong(), anyLong());
+    }
+
+    @Test
+    @DisplayName("내림차순 스코어를 순위로 매핑해 페이지를 구성한다")
+    void getRankingPage_maps_member_scores_to_rank_items() {
+        RankingFacade sut = new RankingFacade(rankingRepository);
+
+        when(rankingRepository.size(anyString())).thenReturn(3L);
+        when(rankingRepository.reverseRangeWithScores(anyString(), eq(0L), eq(1L)))
+                .thenReturn(List.of(
+                        new RankingRepository.MemberScore(101L, 7.5),
+                        new RankingRepository.MemberScore(202L, 3.2)
+                ));
+
+        RankingPage page = sut.getRankingPage(LocalDate.of(2025, 9, 11), 1, 2);
+
+        assertThat(page.total()).isEqualTo(3);
+        assertThat(page.page()).isEqualTo(1);
+        assertThat(page.size()).isEqualTo(2);
+        assertThat(page.items()).hasSize(2);
+
+        RankingItem first = page.items().get(0);
+        assertThat(first.productId()).isEqualTo(101L);
+        assertThat(first.score()).isEqualTo(7.5);
+        assertThat(first.rank()).isEqualTo(1L);
+
+        RankingItem second = page.items().get(1);
+        assertThat(second.productId()).isEqualTo(202L);
+        assertThat(second.score()).isEqualTo(3.2);
+        assertThat(second.rank()).isEqualTo(2L);
+
+        verify(rankingRepository).size(anyString());
+        verify(rankingRepository).reverseRangeWithScores(anyString(), eq(0L), eq(1L));
+        verifyNoMoreInteractions(rankingRepository);
+    }
+
+    @Test
+    @DisplayName("오늘의 단건 랭킹이 존재하면 0-based rank를 +1하여 반환한다")
+    void getTodayRankOf_present() {
+        RankingFacade sut = new RankingFacade(rankingRepository);
+
+        when(rankingRepository.reverseRank(anyString(), eq(555L))).thenReturn(Optional.of(0L));
+        when(rankingRepository.score(anyString(), eq(555L))).thenReturn(Optional.of(9.99));
+
+        Optional<RankingItem> opt = sut.getTodayRankOf(555L);
+
+        assertThat(opt).isPresent();
+        RankingItem item = opt.get();
+        assertThat(item.productId()).isEqualTo(555L);
+        assertThat(item.rank()).isEqualTo(1L);
+        assertThat(item.score()).isEqualTo(9.99);
+
+        verify(rankingRepository).reverseRank(anyString(), eq(555L));
+        verify(rankingRepository).score(anyString(), eq(555L));
+        verifyNoMoreInteractions(rankingRepository);
+    }
+
+    @Test
+    @DisplayName("오늘의 단건 랭킹이 없으면 빈 Optional을 반환한다")
+    void getTodayRankOf_absent() {
+        RankingFacade sut = new RankingFacade(rankingRepository);
+
+        when(rankingRepository.reverseRank(anyString(), eq(42L))).thenReturn(Optional.empty());
+
+        Optional<RankingItem> opt = sut.getTodayRankOf(42L);
+
+        assertThat(opt).isEmpty();
+
+        verify(rankingRepository).reverseRank(anyString(), eq(42L));
+        verify(rankingRepository, never()).score(anyString(), anyLong());
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/application/ranking/RankingFacadeIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/ranking/RankingFacadeIntegrationTest.java
@@ -6,6 +6,7 @@ import com.loopers.domain.ranking.RankingRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -20,10 +21,12 @@ import static org.mockito.Mockito.*;
 public class RankingFacadeIntegrationTest {
     @Mock RankingRepository rankingRepository;
 
+    @InjectMocks
+    RankingFacade sut;
+
     @Test
     @DisplayName("총 개수가 0이면 빈 페이지를 반환한다")
     void getRankingPage_empty_when_total_zero() {
-        RankingFacade sut = new RankingFacade(rankingRepository);
         when(rankingRepository.size(anyString())).thenReturn(0L);
 
         RankingPage page = sut.getRankingPage(LocalDate.of(2025, 9, 11), 1, 10);
@@ -40,7 +43,6 @@ public class RankingFacadeIntegrationTest {
     @Test
     @DisplayName("내림차순 스코어를 순위로 매핑해 페이지를 구성한다")
     void getRankingPage_maps_member_scores_to_rank_items() {
-        RankingFacade sut = new RankingFacade(rankingRepository);
 
         when(rankingRepository.size(anyString())).thenReturn(3L);
         when(rankingRepository.reverseRangeWithScores(anyString(), eq(0L), eq(1L)))
@@ -74,7 +76,6 @@ public class RankingFacadeIntegrationTest {
     @Test
     @DisplayName("오늘의 단건 랭킹이 존재하면 0-based rank를 +1하여 반환한다")
     void getTodayRankOf_present() {
-        RankingFacade sut = new RankingFacade(rankingRepository);
 
         when(rankingRepository.reverseRank(anyString(), eq(555L))).thenReturn(Optional.of(0L));
         when(rankingRepository.score(anyString(), eq(555L))).thenReturn(Optional.of(9.99));
@@ -95,7 +96,6 @@ public class RankingFacadeIntegrationTest {
     @Test
     @DisplayName("오늘의 단건 랭킹이 없으면 빈 Optional을 반환한다")
     void getTodayRankOf_absent() {
-        RankingFacade sut = new RankingFacade(rankingRepository);
 
         when(rankingRepository.reverseRank(anyString(), eq(42L))).thenReturn(Optional.empty());
 

--- a/apps/commerce-api/src/test/java/com/loopers/domain/like/LikeServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/like/LikeServiceIntegrationTest.java
@@ -1,6 +1,7 @@
 package com.loopers.domain.like;
 
 import com.loopers.domain.brand.*;
+import com.loopers.domain.like.event.LikeChangedEvent;
 import com.loopers.domain.product.*;
 import com.loopers.domain.user.UserInfo;
 import com.loopers.domain.brand.BrandCommand;
@@ -16,10 +17,15 @@ import com.loopers.utils.DatabaseCleanUp;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationEventPublisher;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
 
 @SpringBootTest
 @DisplayName("LikeService 통합 테스트")
@@ -131,5 +137,50 @@ public class LikeServiceIntegrationTest {
         assertEquals(userInfo.id(), likeInfo.userId());
         assertEquals(productInfo.id(), likeInfo.productId());
         assertFalse(likeInfo.isLike());
+    }
+
+
+    @DisplayName("새로 좋아요를 등록하면 likeChangedEvent가 발행된다.")
+    @Test
+    void like_LikeChangedEvent_check() {
+        LikeRepository likeRepository = mock(LikeRepository.class);
+        ApplicationEventPublisher publisher = mock(ApplicationEventPublisher.class);
+
+        LikeService sut = new LikeService(likeRepository, publisher);
+
+        when(likeRepository.existsByUserIdAndProductId(1L, 101L)).thenReturn(false);
+        when(likeRepository.save(any(LikeEntity.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        sut.like(new LikeCommand.Create(1L, 101L));
+
+        verify(likeRepository).save(any(LikeEntity.class));
+
+        ArgumentCaptor<Object> cap = ArgumentCaptor.forClass(Object.class);
+        verify(publisher).publishEvent(cap.capture());
+        assertThat(cap.getValue()).isInstanceOf(LikeChangedEvent.class);
+        LikeChangedEvent e = (LikeChangedEvent) cap.getValue();
+        assertThat(e.productId()).isEqualTo(101L);
+        assertThat(e.delta()).isEqualTo(+1);
+    }
+
+    @DisplayName("좋아요가 삭제되면 likeChangedEvent가 발행된다.")
+    @Test
+    void unlike_LikeChangedEvent_check() {
+        LikeRepository likeRepository = mock(LikeRepository.class);
+        ApplicationEventPublisher publisher = mock(ApplicationEventPublisher.class);
+
+        LikeService sut = new LikeService(likeRepository, publisher);
+
+        when(likeRepository.deleteByUserIdAndProductId(1L, 101L)).thenReturn(1);
+
+        sut.unlike(new LikeCommand.Create(1L, 101L));
+
+        verify(likeRepository).deleteByUserIdAndProductId(1L, 101L);
+
+        ArgumentCaptor<Object> cap = ArgumentCaptor.forClass(Object.class);
+        verify(publisher).publishEvent(cap.capture());
+        LikeChangedEvent e = (LikeChangedEvent) cap.getValue();
+        assertThat(e.productId()).isEqualTo(101L);
+        assertThat(e.delta()).isEqualTo(-1);
     }
 }

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/api/ranking/RankingV1ApiE2ETest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/api/ranking/RankingV1ApiE2ETest.java
@@ -1,0 +1,52 @@
+package com.loopers.interfaces.api.ranking;
+
+import com.loopers.application.ranking.RankingFacade;
+import com.loopers.domain.ranking.RankingItem;
+import com.loopers.domain.ranking.RankingPage;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@DisplayName("Ranking API E2E 테스트")
+@WebMvcTest(RankingV1Controller.class)
+public class RankingV1ApiE2ETest {
+
+    @Autowired MockMvc mvc;
+    @MockitoBean RankingFacade rankingFacade;
+
+    @Test
+    @DisplayName("랭킹 페이지를 JSON으로 반환한다")
+    void getRankings_jsonContract() throws Exception {
+        var items = List.of(
+                new RankingItem(101L, 9.9, 1L),
+                new RankingItem(202L, 7.7, 2L)
+        );
+        var page = new RankingPage(items, 1, 2, 10);
+        when(rankingFacade.getRankingPage(any(LocalDate.class), eq(1), eq(2)))
+                .thenReturn(page);
+
+        mvc.perform(get("/api/v1/rankings")
+                        .param("date", "20250911")
+                        .param("page", "1")
+                        .param("size", "2"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.page").value(1))
+                .andExpect(jsonPath("$.data.size").value(2))
+                .andExpect(jsonPath("$.data.total").value(10))
+                .andExpect(jsonPath("$.data.items[0].productId").value(101))
+                .andExpect(jsonPath("$.data.items[0].rank").value(1))
+                .andExpect(jsonPath("$.data.items[0].score").value(9.9));
+    }
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/application/ranking/RankingBatchAggregator.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/application/ranking/RankingBatchAggregator.java
@@ -17,6 +17,6 @@ public class RankingBatchAggregator {
 
     public void apply(LocalDate date, Map<String, Double> productDeltas) {
         if (productDeltas == null || productDeltas.isEmpty()) return;
-        rankingRepository.incrementScores(RankingPolicy.all(date), productDeltas, RankingPolicy.expireAt(date));
+        rankingRepository.incrementScores(RankingPolicy.all(date), productDeltas, RankingPolicy.expireAt());
     }
 }

--- a/apps/commerce-streamer/src/main/java/com/loopers/application/ranking/RankingBatchAggregator.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/application/ranking/RankingBatchAggregator.java
@@ -1,0 +1,22 @@
+package com.loopers.application.ranking;
+
+
+import com.loopers.domain.ranking.RankingPolicy;
+import com.loopers.domain.ranking.RankingRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class RankingBatchAggregator {
+
+    private final RankingRepository rankingRepository;
+
+    public void apply(LocalDate date, Map<String, Double> productDeltas) {
+        if (productDeltas == null || productDeltas.isEmpty()) return;
+        rankingRepository.incrementScores(RankingPolicy.all(date), productDeltas, RankingPolicy.expireAt(date));
+    }
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/ranking/DefaultRankingScorePolicy.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/ranking/DefaultRankingScorePolicy.java
@@ -1,0 +1,17 @@
+package com.loopers.domain.ranking;
+
+public class DefaultRankingScorePolicy implements RankingScorePolicy {
+    private final double wView, wLike, wOrder;
+    private final boolean logMode;
+
+    public DefaultRankingScorePolicy(double wView, double wLike, double wOrder, boolean logMode) {
+        this.wView = wView; this.wLike = wLike; this.wOrder = wOrder; this.logMode = logMode;
+    }
+    @Override public double viewDelta() { return wView * 1.0; }
+    @Override public double likeDelta(int delta) { return wLike * delta; }
+    @Override public double orderDelta(long price, long amount) {
+        long base = price * amount;
+        double v = logMode ? Math.log1p(base) : (double) base;
+        return wOrder * v;
+    }
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/ranking/RankingPolicy.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/ranking/RankingPolicy.java
@@ -1,0 +1,18 @@
+package com.loopers.domain.ranking;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+public class RankingPolicy {
+
+    public static final DateTimeFormatter FMT = DateTimeFormatter.BASIC_ISO_DATE;
+
+    public static String all(LocalDate d) { return "ranking:all:" + d.format(FMT); }
+
+    public static Instant expireAt() {
+        return Instant.now().plus(Duration.ofDays(2));
+    }
+
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/ranking/RankingRepository.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/ranking/RankingRepository.java
@@ -1,0 +1,8 @@
+package com.loopers.domain.ranking;
+
+import java.time.Instant;
+import java.util.Map;
+
+public interface RankingRepository {
+    void incrementScores(String key, Map<String, Double> deltas, Instant expireAt);
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/ranking/RankingScorePolicy.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/ranking/RankingScorePolicy.java
@@ -1,0 +1,7 @@
+package com.loopers.domain.ranking;
+
+public interface RankingScorePolicy {
+    double viewDelta();                        // w_view * 1
+    double likeDelta(int delta);               // w_like * (+1/-1)
+    double orderDelta(long price, long amount);// w_order * (raw or log1p)
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/redis/ranking/RedisRankingRepository.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/infrastructure/redis/ranking/RedisRankingRepository.java
@@ -1,0 +1,30 @@
+package com.loopers.infrastructure.redis.ranking;
+
+import com.loopers.domain.ranking.RankingRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.stereotype.Repository;
+
+import java.time.Instant;
+import java.util.Map;
+
+@Repository
+@RequiredArgsConstructor
+public class RedisRankingRepository implements RankingRepository {
+
+    private final StringRedisTemplate redis;
+
+    @Override
+    public void incrementScores(String key, Map<String, Double> deltas, Instant expireAt) {
+        redis.executePipelined((RedisCallback<Object>) connection -> {
+            var s = (StringRedisSerializer) redis.getStringSerializer();
+            byte[] k = s.serialize(key);
+            deltas.forEach((member, delta) ->
+                    connection.zIncrBy(k, delta, s.serialize(member)));
+            connection.expireAt(k, expireAt.getEpochSecond());
+            return null;
+        });
+    }
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/ranking/RankingEventConsumer.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/ranking/RankingEventConsumer.java
@@ -1,0 +1,87 @@
+package com.loopers.interfaces.consumer.ranking;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.loopers.application.ranking.RankingBatchAggregator;
+import com.loopers.domain.ranking.DefaultRankingScorePolicy;
+import com.loopers.interfaces.consumer.ranking.event.OrderPlacedEvent;
+import com.loopers.interfaces.consumer.ranking.event.ProductLikedEvent;
+import com.loopers.interfaces.consumer.ranking.event.ProductViewedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class RankingEventConsumer {
+
+    private final ObjectMapper om;
+    private final RankingBatchAggregator aggregator;
+
+    private final DefaultRankingScorePolicy policy =
+            new DefaultRankingScorePolicy(0.1, 0.2, 0.6, true);
+
+    @KafkaListener(
+            topics = {"catalog-events", "order-events"},
+            containerFactory = "batchKafkaListenerContainerFactory",
+            groupId = "ranking-agg"
+    )
+    public void onBatch(List<ConsumerRecord<String, String>> records, Acknowledgment ack) {
+        if (records.isEmpty()) {
+            ack.acknowledge();
+            return;
+        }
+
+        Map<String, Double> bucket = new HashMap<>();
+
+        try {
+            for (var r : records) {
+                String type = header(r, "event-type"); // VIEW / LIKE / ORDER
+                if (type == null) continue;
+
+                switch (type) {
+                    case "VIEW" -> {
+                        var e = om.readValue(r.value(), ProductViewedEvent.class);
+                        merge(bucket, String.valueOf(e.productId()), policy.viewDelta());
+                    }
+                    case "LIKE" -> {
+                        var e = om.readValue(r.value(), ProductLikedEvent.class);
+                        merge(bucket, String.valueOf(e.productId()), policy.likeDelta(e.delta()));
+                    }
+                    case "ORDER" -> {
+                        var e = om.readValue(r.value(), OrderPlacedEvent.class);
+                        for (var it : e.items()) {
+                            merge(bucket, String.valueOf(it.productId()), policy.orderDelta(it.price(), it.amount()));
+                        }
+                    }
+                    default -> log.debug("skip unknown event-type={}", type);
+                }
+            }
+
+            LocalDate today = LocalDate.now();
+            aggregator.apply(today, bucket);
+
+            ack.acknowledge();
+        } catch (Exception ex) {
+            log.error("ranking batch failed; will retry", ex);
+        }
+    }
+
+    private static void merge(Map<String, Double> bucket, String productId, double delta) {
+        bucket.merge(productId, delta, Double::sum);
+    }
+
+    private static String header(ConsumerRecord<?, ?> r, String key) {
+        var h = r.headers().lastHeader(key);
+        return h == null ? null : new String(h.value(), StandardCharsets.UTF_8);
+    }
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/ranking/event/OrderPlacedEvent.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/ranking/event/OrderPlacedEvent.java
@@ -1,0 +1,7 @@
+package com.loopers.interfaces.consumer.ranking.event;
+
+
+import java.util.List;
+public record OrderPlacedEvent(String orderId, List<Item> items) {
+    public record Item(long productId, long price, long amount) {}
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/ranking/event/ProductLikedEvent.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/ranking/event/ProductLikedEvent.java
@@ -1,0 +1,3 @@
+package com.loopers.interfaces.consumer.ranking.event;
+
+public record ProductLikedEvent(long productId, Long userId, int delta) {}

--- a/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/ranking/event/ProductViewedEvent.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/ranking/event/ProductViewedEvent.java
@@ -1,0 +1,3 @@
+package com.loopers.interfaces.consumer.ranking.event;
+
+public record ProductViewedEvent(long productId, Long viewerId) {}

--- a/apps/commerce-streamer/src/test/java/com/loopers/interfaces/consumer/ranking/RankingEventConsumerTest.java
+++ b/apps/commerce-streamer/src/test/java/com/loopers/interfaces/consumer/ranking/RankingEventConsumerTest.java
@@ -1,0 +1,86 @@
+package com.loopers.interfaces.consumer.ranking;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.loopers.application.ranking.RankingBatchAggregator;
+import com.loopers.interfaces.consumer.ranking.event.OrderPlacedEvent;
+import com.loopers.interfaces.consumer.ranking.event.ProductLikedEvent;
+import com.loopers.interfaces.consumer.ranking.event.ProductViewedEvent;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.header.Headers;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.kafka.support.Acknowledgment;
+
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.offset;
+import static org.mockito.Mockito.*;
+
+class RankingEventConsumerTest {
+
+    private final ObjectMapper om = new ObjectMapper();
+    private final RankingBatchAggregator aggregator = mock(RankingBatchAggregator.class);
+
+    private final RankingEventConsumer sut = new RankingEventConsumer(om, aggregator);
+
+    @Test
+    @DisplayName("배치 VIEW/LIKE/ORDER를 오늘자 키로 합산하여 Aggregator.apply 호출")
+    void batch_aggregates_and_applies_for_today() throws Exception {
+        List<ConsumerRecord<String, String>> batch = new ArrayList<>();
+
+        // VIEW: product 10, 3회
+        var viewJson = om.writeValueAsString(new ProductViewedEvent(10L, System.currentTimeMillis()));
+        batch.add(record("catalog-events", "VIEW", "10", viewJson));
+        batch.add(record("catalog-events", "VIEW", "10", viewJson));
+        batch.add(record("catalog-events", "VIEW", "10", viewJson));
+
+        // LIKE: product 10, +1
+        var likeJson = om.writeValueAsString(new ProductLikedEvent(10L, 1L, +1));
+        batch.add(record("catalog-events", "LIKE", "10", likeJson));
+
+        // ORDER: order#1, items = [(10, 10000, 2), (20, 5000, 1)]
+        var order = new OrderPlacedEvent("1", List.of(
+                new OrderPlacedEvent.Item(10L, 10_000L, 2L),
+                new OrderPlacedEvent.Item(20L, 5_000L, 1L)
+        ));
+        var orderJson = om.writeValueAsString(order);
+        batch.add(record("order-events", "ORDER", "1", orderJson));
+
+        Acknowledgment ack = mock(Acknowledgment.class);
+
+        sut.onBatch(batch, ack);
+
+        // then
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Map<String, Double>> bucketCap = ArgumentCaptor.forClass(Map.class);
+        ArgumentCaptor<LocalDate> dateCap = ArgumentCaptor.forClass(LocalDate.class);
+
+        verify(aggregator, times(1)).apply(dateCap.capture(), bucketCap.capture());
+        assertThat(dateCap.getValue()).isEqualTo(LocalDate.now());
+
+        Map<String, Double> bucket = bucketCap.getValue();
+        assertThat(bucket).containsKeys("10", "20");
+
+        // 기대값 계산 (정책: view 0.1, like 0.2*delta, order 0.6*log1p(price*amount))
+        double expected10 = (3 * 0.1) + (1 * 0.2) + (0.6 * Math.log1p(10_000L * 2L));
+        double expected20 = (0.6 * Math.log1p(5_000L * 1L));
+
+        assertThat(bucket.get("10")).isCloseTo(expected10, offset(1e-6));
+        assertThat(bucket.get("20")).isCloseTo(expected20, offset(1e-6));
+
+        verifyNoMoreInteractions(aggregator);
+    }
+
+    private static ConsumerRecord<String, String> record(String topic, String type, String key, String json) {
+        ConsumerRecord<String, String> r = new ConsumerRecord<>(topic, 0, 0L, key, json);
+        Headers headers = r.headers();
+        headers.add("event-type", type.getBytes(StandardCharsets.UTF_8));
+        return r;
+    }
+}

--- a/modules/kafka/src/main/java/com/loopers/config/kafka/KafkaBatchConfig.java
+++ b/modules/kafka/src/main/java/com/loopers/config/kafka/KafkaBatchConfig.java
@@ -1,0 +1,20 @@
+package com.loopers.config.kafka;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.listener.ContainerProperties;
+
+public class KafkaBatchConfig {
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, String> batchKafkaListenerContainerFactory(
+            ConsumerFactory<String, String> cf) {
+        var f = new ConcurrentKafkaListenerContainerFactory<String, String>();
+        f.setConsumerFactory(cf);
+        f.setBatchListener(true);
+        f.setConcurrency(3);
+        f.getContainerProperties().setAckMode(ContainerProperties.AckMode.MANUAL_IMMEDIATE);
+        return f;
+    }
+}


### PR DESCRIPTION
## 📌 Summary
- Redis Sorted Set (ZSET)
- ZINCRBY 기반 실시간 집계
- Top-N API
- 일별 Key 전략 & TTL

## 💬 Review Points
1. 아래와 같은 구조로 구현하였는데 이벤트 처리의 큰 틀이 맞는지 확인 부탁드립니다!

commerce-api
- (producer) 조회/좋아요/주문 이벤트 발행
- (read API) Redis ZSET에서 랭킹 읽어와 응답

commerce-streamer
- (consumer) Kafka 배치 리스너로 이벤트 묶음 처리
- (aggregator) productId별 점수 합치기 → Redis ZSET에 ZINCRBY 파이프라인
- 키: ranking:all:{yyyyMMdd} , TTL: 2일

2. 랭킹 집계의 시간 기준을 처리시각(컨슈머가 처리한 순간) vs 발생시각(이벤트가 일어난 시각) 중 무엇으로 설정해야 하는지 궁금합니다. 현재는 일간 집계만 적용하여서 처리시각으로 설정하였는데, 어제/지난 주 랭킹이나 주간/월간 랭킹등을 구현하려면 발생시각 기준으로 변경이 필요할까요?

3. 랭킹 점수 계산을 전략패턴으로 분리해 RankingPolicy 인터페이스를 구현하여 이번 과제에서 (view=0.1, like=0.2, order=0.7) 로 설정하였습니다. 실무에서도 지표/가중치 전략을 바꿔가며 운영하시는지, 일/주/월 같이 기간별로 전략을 나눠 쓰시는지 궁금합니다!

## ✅ Checklist
### 📈 Ranking Consumer

- [x]  랭킹 ZSET 의 TTL, 키 전략을 적절하게 구성하였다
- [x]  날짜별로 적재할 키를 계산하는 기능을 만들었다
- [x]  이벤트가 발생한 후, ZSET 에 점수가 적절하게 반영된다

### ⚾ Ranking API

- [x]  랭킹 Page 조회 시 정상적으로 랭킹 정보가 반환된다
- [x]  랭킹 Page 조회 시 단순히 상품 ID 가 아닌 상품정보가 Aggregation 되어 제공된다
- [x]  상품 상세 조회 시 해당 상품의 순위가 함께 반환된다 (순위에 없다면 null)

## 📎 References
